### PR TITLE
Generator: haskell: return malloc data instead of local static

### DIFF
--- a/tools/generator/gen/generator_haskell.rb
+++ b/tools/generator/gen/generator_haskell.rb
@@ -278,12 +278,14 @@ Lang_array cxx2lang_array(const std::vector<Cxx>& in)
 template<typename Lang, typename Lang_array, typename Cxx>
 Lang_array* cxx2lang_array_ptr(const std::vector<Cxx>& in)
 {
-  static Lang_array out; out = { NULL, in.size() };
-  out.datas = (Lang *)malloc((out.length) * sizeof(Lang));
-  __internal_need_free.push_back(out.datas);
-  for (int i = 0; i < out.length; ++i)
-    out.datas[i] = cxx2lang<Lang, Cxx>(in[i]);
-  return &out;
+  Lang_array* out = (Lang_array*)malloc(sizeof (Lang_array));
+  __internal_need_free.push_back(out);
+  *out = { NULL, in.size() };
+  out->datas = (Lang *)malloc((out->length) * sizeof(Lang));
+  __internal_need_free.push_back(out->datas);
+  for (int i = 0; i < out->length; ++i)
+    out->datas[i] = cxx2lang<Lang, Cxx>(in[i]);
+  return out;
 }
 EOF
 
@@ -336,14 +338,15 @@ EOF
 template<>
 #{ctype}* cxx2lang<#{ctype}*, #{cxxtype}>(#{cxxtype} in)
 {
-  static #{ctype} out;
+  #{ctype}* out = (#{ctype}*)malloc(sizeof (#{ctype}));
+  __internal_need_free.push_back(out);
 EOF
       x['str_field'].each do |f|
         name = f[0]
         type = @types[f[1]]
-        @f.puts "  out.#{name} = #{hs_get_cxx2lang(type)}(in.#{name});"
+        @f.puts "  out->#{name} = #{hs_get_cxx2lang(type)}(in.#{name});"
       end
-      @f.puts "  return &out;", "}", ""
+      @f.puts "  return out;", "}", ""
     end
 
     for_each_fun false do |fn|


### PR DESCRIPTION
This allows to call cxx2lang_array_ptr and cxx2lang multiple times
without overwriting a previous array.

This also makes these functions not a unique symbol anymore and allows
haskell's interface.cc to be compiled using the SYSV ABI. Unique symbols
are a GNU extension, using them forces us to compile using the GNU/Linux
ABI while we compile everything else with SYSV ABI.