### PR TITLE
Add Rust support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ tools/generator/test/java
 tools/generator/test/php
 tools/generator/test/haskell
 tools/generator/test/python
+tools/generator/test/rust
 tools/generator/test/README
 games/*
 !games/tictactoe

--- a/tools/generator/files/useapi.tex
+++ b/tools/generator/files/useapi.tex
@@ -7,7 +7,7 @@
       tableaux utilisent à la place de ces tableaux une structure
       \texttt{type\_array}, où \texttt{type} est le type des données dans le
       tableau. Ces structures contiennent deux éléments : les données,
-      \texttt{type* datas}, et la taille, \texttt{size\_t size}. Dans tous les
+      \texttt{type* datas}, et la taille, \texttt{size\_t length}. Dans tous les
       cas, la libération des données est laissée au soin du candidat ;}
 \item{Tout le reste est comme indiqué dans le sujet.}
 \end{itemize}
@@ -108,4 +108,22 @@ fonctionACompleter = do
       on peut accéder aux champs via la notation pointée habituelle, et
       qui peuvent être créés comme ceci : \texttt{foo(bar=42, x=3)}, sauf pour
       la structure \texttt{position} qui est représentée par un couple (x, y).}
+\end{itemize}
+
+\subsection{Rust}
+
+\begin{itemize}
+\item{L'API est fournie par le module \texttt{api}, dont tout le contenu est
+      importé par défaut par le code à compléter. ;}
+\item{Les noms des structures et énumérations sont en \texttt{CamelCase}.
+      Ainsi, une structure nommée \texttt{foo\_bar} dans le sujet
+      s'appellera \texttt{FooBar} en Rust.}
+\item{Les fonctions prenant des tableaux en paramètres et retournant des
+      tableaux utilisent à la place de ces tableaux une structure
+      \texttt{Array<T>}, où \texttt{T} est le type des données dans le
+      tableau. Ces structures contiennent deux éléments : les données,
+      \texttt{ptr: *const T}, et la taille, \texttt{len: usize}.
+      Dans tous les cas, la libération des données est laissée au soin du
+      candidat, en utilisant la méthode \texttt{unsafe fn free(self: Array<T>);}
+      fournie. ;}
 \end{itemize}

--- a/tools/generator/gen/generator_c.rb
+++ b/tools/generator/gen/generator_c.rb
@@ -243,6 +243,7 @@ EOF
 end
 
 class CFileGenerator < CProto
+  attr_accessor :path, :header_file
   def generate_header
     @f = File.open(@path + @header_file, 'w')
     print_banner "generator_c.rb"
@@ -336,4 +337,3 @@ include ../includes/rules.mk
     generate_makefile
   end
 end
-

--- a/tools/generator/gen/generator_rust.rb
+++ b/tools/generator/gen/generator_rust.rb
@@ -1,0 +1,193 @@
+# -*- ruby -*-
+# Stechec project is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# The complete GNU General Public Licence Notice can be found as the
+# `NOTICE' file in the root directory.
+#
+# Copyright (C) 2005, 2006, 2007, 2018 Prologin
+#
+
+require "pathname"
+require "gen/file_generator"
+require "gen/generator_c"
+
+def rust_typename(type)
+  if type.name == "string"
+    "*const char"
+  elsif type.name == "bool"
+    "bool"
+  elsif type.is_array?
+     "Array<" + rust_typename(type.type) + ">"
+  elsif ["int", "float", "double"].include? type.name
+    "c_" + type.name
+  else
+    camel_case(type.name)
+  end
+end
+
+def rust_proto(fn)
+  # Returns the prototype of a C function
+  args = fn.args.map { |arg| "#{arg.name}: #{rust_typename(arg.type)}" }.join(", ")
+  ret = fn.ret.is_nil? ? "" : " -> #{rust_typename(fn.ret)}"
+  "fn #{fn.name}(#{args})" + ret
+end
+
+class CCxxFileGeneratorForRust < CCxxFileGenerator
+  def build
+    @path = Pathname.new($install_path) + "rust"
+    @source_file = 'interface.cc'
+    @header_file = 'interface.hh'
+
+    generate_source
+    generate_header
+  end
+end
+
+class RustFileGenerator < FileGenerator
+  def print_multiline_comment(str, prestr = '')
+    str.each_line {|s| @f.print prestr, "// ", s }
+    @f.puts
+  end
+
+  # must be called right after print_proto
+  def print_body(content)
+    @f.puts "", "{"
+    @f.puts content
+    @f.puts "}"
+  end
+
+  def print_constant(type, name, val)
+      @f.puts "pub const #{name}: c_#{type} = #{val};"
+  end
+
+  def build_enums
+    for_each_enum do |x|
+      @f.puts "#[repr(C)]"
+      @f.puts "#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]"
+      @f.puts "pub enum #{camel_case(x['enum_name'])} {"
+      x['enum_field'].each do |f|
+        name = camel_case(f[0])
+        @f.print "  /// ", f[1], "\n"
+        @f.print "  ", name, ", \n"
+      end
+      @f.puts "}"
+    end
+  end
+
+  def build_structs_generic(&show_field)
+    for_each_struct do |x|
+      @f.puts "#[repr(C)]"
+      @f.puts "#[derive(Clone)]"
+      @f.puts "pub struct #{camel_case(x['str_name'])} {"
+      x['str_field'].each do |f|
+        @f.print "  /// ", f[2], "\n"
+        @f.print "  pub ", show_field.call(f[0], f[1]), ", \n"
+      end
+      @f.print "}\n\n"
+    end
+  end
+
+  def generate_api
+    @f = File.open(@path + @api_file, 'w')
+    print_banner "generator_rust.rb"
+        @f.puts <<-EOF
+#![allow(unused)]
+use std::os::raw::{c_double, c_int, c_void};
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct Array<T> {
+    pub ptr: *const T,
+    pub len: usize,
+}
+
+impl<T> Array<T> {
+    // Doit etre appele exactement une fois par `Array`
+    // retourne par une fonction de l'API.
+    pub unsafe fn free(self) {
+      free(self.ptr as _);
+    }
+}
+EOF
+
+    build_constants
+    build_enums
+
+    build_structs_generic do |field, type|
+      type = @types[type]
+      "#{field}: #{rust_typename(type)}"
+    end
+
+    @f.puts "extern {"
+    @f.puts "fn free(p: *mut c_void);", ""
+    for_each_fun do |f|
+      @f.print "pub ", rust_proto(f), ";\n"
+    end
+    @f.puts "}", ""
+    for_each_user_fun do |f|
+      @f.puts"#[no_mangle]"
+      @f.print "pub unsafe extern \"C\" ", rust_proto(f)
+      args = f.args.map { |arg| arg.name }.join(", ")
+      print_body "  super::#{f.name}(#{args})"
+    end
+    @f.close
+  end
+
+  def generate_user
+    @f = File.open(@path + @user_file, 'w')
+    @f.puts "#![allow(unused)]"
+    @f.puts "pub mod api;"
+    @f.puts "use api::*;"
+    @f.puts "use std::os::raw::{c_double, c_int, c_void};", ""
+    for_each_user_fun do |f|
+      @f.print rust_proto(f)
+      print_body "  // fonction a completer"
+    end
+    @f.close
+  end
+
+  def generate_makefile
+    target = $conf['conf']['player_lib']
+    @f = File.open(@path + "Makefile", 'w')
+    @f.print <<-EOF
+# -*- Makefile -*-
+
+lib_TARGETS = #{target}
+
+# Tu peux rajouter des fichiers sources ou changer des flags de compilation.
+#{target}-dists =
+#{target}-rustcflags = -g
+
+# Evite de toucher a ce qui suit
+#{target}-dists += #{$conf['conf']['player_filename']}.h interface.hh #{@api_file}
+#{target}-srcs += interface.cc #{@user_file}
+#{target}-ldflags = -fPIC -Wl,--whole-archive
+#{target}-ldlibs  = -Wl,--no-whole-archive -lm -lrt -ldl -lpthread -lstdc++
+
+STECHEC_LANG=rust
+include ../includes/rules.mk
+    EOF
+    @f.close
+  end
+
+
+  def build()
+    CCxxFileGeneratorForRust.new.build
+
+    @path = Pathname.new($install_path) + "rust"
+    @user_file = $conf['conf']['player_filename'] + '.rs'
+    @api_file = 'api.rs'
+
+    header_generator = CFileGenerator.new
+    header_generator.path = Pathname.new($install_path) + "rust"
+    header_generator.header_file = $conf['conf']['player_filename'] + '.h'
+
+    header_generator.generate_header
+    generate_user
+    generate_api
+    generate_makefile
+  end
+end

--- a/tools/generator/gen/makefile_rust.rb
+++ b/tools/generator/gen/makefile_rust.rb
@@ -1,0 +1,33 @@
+#
+# Stechec project is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# The complete GNU General Public Licence Notice can be found as the
+# `NOTICE' file in the root directory.
+#
+# Copyright (C) 2005, 2006, 2018 Prologin
+#
+
+class RustMakefile
+  def build_metaserver(path)
+    f = File.new(path + "Makefile-rust", 'w')
+    target = $conf['conf']['player_lib']
+    f.print <<-EOF
+# -*- Makefile -*-
+
+lib_TARGETS = #{target}
+
+#{target}-srcs = interface.cc #{$conf['conf']['player_filename']}.rs
+#{target}-rustcflags = -O
+#{target}-ldflags = -fPIC -Wl,--whole-archive
+#{target}-ldlibs  = -Wl,--no-whole-archive -lm -lrt -ldl -lpthread -lstdc++
+
+V=1
+include $(MFPATH)/rules.mk
+    EOF
+    f.close
+  end
+
+end

--- a/tools/generator/generator.rb
+++ b/tools/generator/generator.rb
@@ -113,6 +113,7 @@ def make_includes
 #   PascalMakefile.new.build_client(install_path)
 #   PrologMakefile.new.build_client(install_path)
 #   RubyMakefile.new.build_client(install_path)
+#   RustMakefile.new.build_client(install_path)
 #   JsMakefile.new.build_client(install_path)
 #   LuaMakefile.new.build_client(install_path)
 end
@@ -138,6 +139,7 @@ def make_server
   PhpMakefile.new.build_metaserver(install_path)
   # PrologMakefile.new.build_metaserver(install_path)
   # RubyMakefile.new.build_metaserver(install_path) TODO
+  RustMakefile.new.build_metaserver(install_path)
   # JsMakefile.new.build_metaserver(install_path) TODO
   # copy some used files
   path = Pathname.new(PKGDATADIR) + "files"

--- a/tools/generator/generator.rb
+++ b/tools/generator/generator.rb
@@ -53,7 +53,7 @@ require 'fileutils'
 require 'pathname'
 require 'conf'
 
-$languages = %w[c cs cxx caml java python php haskell]
+$languages = %w[c cs cxx caml java python php rust haskell]
 
 def make_player
   $languages.each do |x|
@@ -76,6 +76,7 @@ def make_player
   JavaFileGenerator.new.build
   HaskellFileGenerator.new.build
 #  RubyFileGenerator.new.build
+  RustFileGenerator.new.build
 #  LuaFileGenerator.new.build
   PythonFileGenerator.new.build
   PhpFileGenerator.new.build

--- a/tools/generator/test/champions/prologin.rs
+++ b/tools/generator/test/champions/prologin.rs
@@ -1,0 +1,131 @@
+#![allow(bad_style, unused)]
+pub mod api;
+use api::*;
+use std::os::raw::{c_double, c_int, c_void};
+use std::slice::from_raw_parts;
+
+/// Called 10K times to test if things work well.
+unsafe fn test()
+{
+    assert!(CONST_VAL/4 == 10);
+    assert!(CONST_DOUBLE_2/2. == 668.5);
+
+    send_me_42(42);
+    send_me_42_and_1337(42, 1337);
+    send_me_true(true);
+    send_me_tau(6.2831853);
+    assert!(returns_42() == 42);
+    assert!(returns_true() == true);
+    assert!((returns_tau() - 6.2831).abs() < 0.001);
+
+    let r = returns_range(1, 100);
+    {
+        let rs = from_raw_parts(r.ptr, r.len);
+        for i in 1..100 {
+            assert!(rs[i - 1] == i as i32);
+        }
+    }
+    r.free();
+
+    let r = returns_range(1, 10000);
+    {
+        let rs = from_raw_parts(r.ptr, r.len);
+        for i in 1..10000 {
+            assert!(rs[i - 1] == i as i32);
+        }
+    }
+    r.free();
+
+    let vr = vec![1, 3, 2, 4, 5, 7, 6];
+    let v = Array {
+        ptr: vr.as_ptr(),
+        len: vr.len(),
+    };
+    let v = returns_sorted(v);
+    {
+        let vs = from_raw_parts(v.ptr, v.len);
+        for i in 0..7 {
+            assert!(vs[i] == (i + 1) as i32);
+        }
+    }
+    v.free();
+
+    {
+        let sr = vec![42; 42];
+        let ss = vec![SimpleStruct {
+            field_i: 42,
+            field_bool: true,
+            field_double: 42.42,
+        }; 42];
+        let s = StructWithArray {
+            field_int: 42,
+            field_int_arr: Array {
+                ptr: sr.as_ptr(),
+                len: sr.len(),
+            },
+            field_str_arr: Array {
+                ptr: ss.as_ptr(),
+                len: ss.len(),
+            },
+        };
+        send_me_42s(s);
+    }
+
+    send_me_test_enum(TestEnum::Val1, TestEnum::Val2);
+
+    let vi = (0..42).map(|_| vec![42; 42]).collect::<Vec<_>>();
+    let vs = (0..42).map(|_| {
+        (0..42).map(|_| SimpleStruct {
+            field_i: 42,
+            field_bool: true,
+            field_double: 42.42,
+        }).collect::<Vec<_>>()
+    }).collect::<Vec<_>>();
+
+    let l = (0..42).map(|i| {
+        StructWithArray {
+            field_int: 42,
+            field_int_arr: Array {
+                ptr: vi[i].as_ptr(),
+                len: vi[i].len(),
+            },
+            field_str_arr: Array {
+                ptr: vs[i].as_ptr(),
+                len: vs[i].len(),
+            },
+        }
+    }).collect::<Vec<_>>();
+    let ll = Array {
+        ptr: l.as_ptr(),
+        len: l.len(),
+    };
+    let ll = send_me_struct_array(ll);
+    assert!(ll.len == 42);
+    {
+        let lls = from_raw_parts(ll.ptr, ll.len);
+
+        for l in lls
+        {
+            assert!(l.field_int == 42);
+            assert!(l.field_int_arr.len == 42);
+            assert!(l.field_str_arr.len == 42);
+            {
+                let is = from_raw_parts(l.field_int_arr.ptr, l.field_int_arr.len);
+                let ss = from_raw_parts(l.field_str_arr.ptr, l.field_str_arr.len);
+                for &i in is {
+                    assert!(i == 42);
+                }
+                for s in ss
+                {
+                    assert!(s.field_i == 42);
+                    assert!(s.field_bool == true);
+                    assert!(s.field_double == 42.42);
+                }
+            }
+            l.clone().field_int_arr.free();
+            l.clone().field_str_arr.free();
+        }
+    }
+    ll.free();
+
+}

--- a/tools/generator/test/testall.sh
+++ b/tools/generator/test/testall.sh
@@ -38,6 +38,7 @@ runtest java Prologin.java
 runtest caml prologin.ml
 runtest cxx prologin.cc
 runtest python prologin.py
+runtest rust prologin.rs
 runtest haskell Prologin.hs
 
 echo

--- a/tools/generator/wscript
+++ b/tools/generator/wscript
@@ -51,6 +51,7 @@ def build(bld):
         'gen/makefile_prolog.rb',
         'gen/makefile_js.rb',
         'gen/makefile_ruby.rb',
+        'gen/makefile_rust.rb',
         'gen/makefile_python.rb',
         'gen/makefile_cs.rb',
         'gen/makefile_lua.rb',

--- a/tools/generator/wscript
+++ b/tools/generator/wscript
@@ -70,6 +70,7 @@ def build(bld):
         'gen/generator_php.rb',
         'gen/generator_caml.rb',
         'gen/generator_ruby.rb',
+        'gen/generator_rust.rb',
         'gen/generator_prolog.rb',
         'gen/generator_haskell.rb',
         'gen/generator_c.rb',


### PR DESCRIPTION
This reuses part of the C generator, by using a C++ <=> C <=> Rust FFI.
The linking is done with whole-archive to properly merge C/C++ and Rust static libraries.

`testall.sh` succeeds on my machine, and I've manually verified the correctness of the generated `prologin2017` environment.
Related to prologin/sadm#102.