### PR TITLE
Wrap the Rust FFI in an idiomatic API

### DIFF
--- a/tools/generator/files/useapi.tex
+++ b/tools/generator/files/useapi.tex
@@ -118,12 +118,5 @@ fonctionACompleter = do
 \item{Les noms des structures et énumérations sont en \texttt{CamelCase}.
       Ainsi, une structure nommée \texttt{foo\_bar} dans le sujet
       s'appellera \texttt{FooBar} en Rust.}
-\item{Les fonctions prenant des tableaux en paramètres et retournant des
-      tableaux utilisent à la place de ces tableaux une structure
-      \texttt{Array<T>}, où \texttt{T} est le type des données dans le
-      tableau. Ces structures contiennent deux éléments : les données,
-      \texttt{ptr: *const T}, et la taille, \texttt{len: usize}.
-      Dans tous les cas, la libération des données est laissée au soin du
-      candidat, en utilisant la méthode \texttt{unsafe fn free(self: Array<T>);}
-      fournie. ;}
+\item{Les tableaux sont représentés par des \texttt{Vec<T>}.}
 \end{itemize}

--- a/tools/generator/gen/generator_rust.rb
+++ b/tools/generator/gen/generator_rust.rb
@@ -12,15 +12,14 @@
 
 require "pathname"
 require "gen/file_generator"
-require "gen/generator_c"
 
-def rust_typename(type)
+def rust_ffi_typename(type)
   if type.name == "string"
     "*const char"
   elsif type.name == "bool"
     "bool"
   elsif type.is_array?
-     "Array<" + rust_typename(type.type) + ">"
+     "Array<" + rust_ffi_typename(type.type) + ">"
   elsif ["int", "float", "double"].include? type.name
     "c_" + type.name
   else
@@ -28,14 +27,135 @@ def rust_typename(type)
   end
 end
 
-def rust_proto(fn)
+def rust_api_typename(type)
+  if type.is_array?
+     "Vec<" + rust_api_typename(type.type) + ">"
+   else
+     rust_ffi_typename(type)
+   end
+end
+
+def rust_ffi_proto(fn)
   # Returns the prototype of a C function
-  args = fn.args.map { |arg| "#{arg.name}: #{rust_typename(arg.type)}" }.join(", ")
-  ret = fn.ret.is_nil? ? "" : " -> #{rust_typename(fn.ret)}"
+  args = fn.args.map { |arg| "#{arg.name}: #{rust_ffi_typename(arg.type)}" }.join(", ")
+  ret = fn.ret.is_nil? ? "" : " -> #{rust_ffi_typename(fn.ret)}"
   "fn #{fn.name}(#{args})" + ret
 end
 
-class CCxxFileGeneratorForRust < CCxxFileGenerator
+def rust_api_proto(fn)
+  # Returns the prototype of a C function
+  args = fn.args.map { |arg| "#{arg.name}: &#{rust_api_typename(arg.type)}" }.join(", ")
+  ret = fn.ret.is_nil? ? "" : " -> #{rust_api_typename(fn.ret)}"
+  "fn #{fn.name}(#{args})" + ret
+end
+
+class RustCxxFileGenerator < CCxxFileGenerator
+  def initialize
+    super
+    @lang = "C++ (for Rust interface)"
+  end
+
+  def generate_source
+    @f = File.open(@path + @source_file, 'w')
+    print_banner "generator_c.rb"
+    @f.puts <<-EOF
+#include "interface.hh"
+#include <cstdlib>
+
+template<typename Lang, typename Cxx>
+Cxx lang2cxx(Lang in)
+{
+  return in;
+}
+
+template<>
+std::string lang2cxx<char*, std::string>(char* in)
+{
+  return in;
+}
+
+template<typename Lang, typename Lang_array, typename Cxx>
+std::vector<Cxx> lang2cxx_array(Lang_array in)
+{
+  std::vector<Cxx> out(in.length);
+  for (size_t i = 0; i < in.length; ++i)
+    out[i] = lang2cxx<Lang, Cxx>(in.datas[i]);
+  free(in.datas);
+  return out;
+}
+
+template<typename Lang, typename Cxx>
+Lang cxx2lang(Cxx in)
+{
+  return in;
+}
+
+template<>
+char* cxx2lang<char*, std::string>(std::string in)
+{
+  size_t l = in.length();
+  char* out = (char *) malloc(l + 1);
+  for (int i = 0; i < l; i++) out[i] = in[i];
+  out[l] = 0;
+  return out;
+}
+
+template<typename Lang, typename Lang_array, typename Cxx>
+Lang_array cxx2lang_array(const std::vector<Cxx>& in)
+{
+  Lang_array out = { NULL, in.size() };
+  out.datas = (Lang *)malloc((out.length) * sizeof(Lang));
+  for (int i = 0; i < out.length; ++i)
+    out.datas[i] = cxx2lang<Lang, Cxx>(in[i]);
+  return out;
+}
+EOF
+
+    for_each_struct do |x|
+      rtype = x['str_name']
+      cxxtype = "__internal__cxx__#{rtype}"
+      @f.puts <<-EOF
+template<>
+#{cxxtype} lang2cxx<#{rtype}, #{cxxtype}>(#{rtype} in)
+{
+  #{cxxtype} out;
+EOF
+      x['str_field'].each do |f|
+        name = f[0]
+        type = @types[f[1]]
+        @f.puts "  out.#{name} = #{get_lang2cxx(type)}(in.#{name});"
+      end
+      @f.puts <<-EOF
+  return out;
+}
+
+template<>
+#{rtype} cxx2lang<#{rtype}, #{cxxtype}>(#{cxxtype} in)
+{
+  #{rtype} out;
+EOF
+      x['str_field'].each do |f|
+        name = f[0]
+        type = @types[f[1]]
+        @f.puts "  out.#{name} = #{get_cxx2lang(type)}(in.#{name});"
+      end
+      @f.puts "  return out;", "}", ""
+    end
+
+    @f.puts <<-EOF
+extern "C" {
+EOF
+    for_each_fun do |fn|
+      @f.puts c_proto(fn)
+      buffer = "api_#{fn.name}("
+      buffer += fn.args.map { |arg| "#{get_lang2cxx(arg.type)}(#{arg.name})" }.join(", ") + ")"
+      buffer = "return #{get_cxx2lang(fn.ret)}(#{buffer})" if not fn.ret.is_nil?
+      @f.puts "{", "  #{buffer};", "}", ""
+    end
+    @f.puts "}"
+    @f.close
+  end
+
   def build
     @path = Pathname.new($install_path) + "rust"
     @source_file = 'interface.cc'
@@ -77,25 +197,43 @@ class RustFileGenerator < FileGenerator
     end
   end
 
-  def build_structs_generic(&show_field)
-    for_each_struct do |x|
-      @f.puts "#[repr(C)]"
-      @f.puts "#[derive(Clone)]"
-      @f.puts "pub struct #{camel_case(x['str_name'])} {"
-      x['str_field'].each do |f|
-        @f.print "  /// ", f[2], "\n"
-        @f.print "  pub ", show_field.call(f[0], f[1]), ", \n"
-      end
-      @f.print "}\n\n"
+  def build_struct_generic(struct, &typename)
+    name = camel_case(struct['str_name'])
+    @f.puts "pub struct #{camel_case(struct['str_name'])} {"
+    struct['str_field'].each do |f|
+      type = @types[f[1]]
+      type = typename.call(type)
+      @f.puts "  /// #{f[2]}"
+      @f.puts "  pub #{f[0]}: #{type},"
     end
+    @f.puts "}"
+    @f.puts
   end
 
-  def generate_api
-    @f = File.open(@path + @api_file, 'w')
+  def impl_conv_id(type)
+    @f.puts "impl ToAPI for #{type} {"
+    @f.puts "  type To = #{type};"
+    @f.puts "  unsafe fn to_api(&self) -> Self::To { self.clone() }"
+    @f.puts "}"
+    @f.puts
+    @f.puts "impl ToFFI for #{type} {"
+    @f.puts "  type To = #{type};"
+    @f.puts "  fn to_ffi(&self) -> Self::To { self.clone() }"
+    @f.puts "}"
+    @f.puts
+  end
+
+  def generate_ffi
+    @f = File.open(@path + @ffi_file, 'w')
     print_banner "generator_rust.rb"
+    @f.puts "use api::{self,"
+    for_each_enum do |x|
+      @f.print "#{camel_case(x['enum_name'])},"
+    end
+    @f.puts "};"
         @f.puts <<-EOF
-#![allow(unused)]
-use std::os::raw::{c_double, c_int, c_void};
+use std::{mem, ptr, slice};
+use std::os::raw::{c_float ,c_double, c_int, c_void};
 
 #[repr(C)]
 #[derive(Clone)]
@@ -104,34 +242,125 @@ pub struct Array<T> {
     pub len: usize,
 }
 
-impl<T> Array<T> {
-    // Doit etre appele exactement une fois par `Array`
-    // retourne par une fonction de l'API.
-    pub unsafe fn free(self) {
-      free(self.ptr as _);
-    }
+pub trait ToAPI {
+  type To;
+  unsafe fn to_api(&self) -> Self::To;
 }
+
+pub trait ToFFI {
+  type To;
+  fn to_ffi(&self) -> Self::To;
+}
+
+impl<T: ToAPI + Clone> ToAPI for Array<T> {
+  type To = Vec<T::To>;
+  unsafe fn to_api(&self) -> Self::To {
+    let vec;
+    {
+      let slice = slice::from_raw_parts(self.ptr, self.len);
+      vec = slice.iter().map(|elem| elem.to_api()).collect();
+    }
+    free(self.ptr as _);
+    vec
+  }
+}
+
+impl<T: ToFFI> ToFFI for Vec<T> {
+  type To = Array<T::To>;
+  fn to_ffi(&self) -> Self::To {
+    unsafe {
+      let ptr: *mut T::To = malloc(self.len() * mem::size_of::<T::To>()) as _;
+      let len = self.len();
+      for i in 0..len {
+        ptr::write(ptr.add(i), self[i].to_ffi());
+      }
+      Array { ptr, len }
+    }
+  }
+}
+
+EOF
+
+    for type in ["()", "c_int", "c_float", "c_double", "bool", "*const char"]
+      impl_conv_id(type)
+    end
+
+    for_each_enum do |x|
+      impl_conv_id(camel_case(x['enum_name']))
+    end
+
+    for_each_struct do |x|
+      name = camel_case(x['str_name'])
+      @f.puts "#[repr(C)]"
+      @f.puts "#[derive(Clone)]"
+      build_struct_generic(x) do |type|
+        rust_ffi_typename(type)
+      end
+
+      @f.puts "impl ToAPI for #{name} {"
+      @f.puts "  type To = api::#{name};"
+      @f.puts "  unsafe fn to_api(&self) -> Self::To {"
+      @f.puts "    api::#{name} {"
+      x['str_field'].each do |f|
+        @f.puts "      #{f[0]}: self.#{f[0]}.to_api(),"
+      end
+      @f.puts "    }"
+      @f.puts "  }"
+      @f.puts "}"
+      @f.puts
+      @f.puts "impl ToFFI for api::#{name} {"
+      @f.puts "  type To = #{name};"
+      @f.puts "  fn to_ffi(&self) -> Self::To {"
+      @f.puts "    #{name} {"
+      x['str_field'].each do |f|
+        @f.puts "      #{f[0]}: self.#{f[0]}.to_ffi(),"
+      end
+      @f.puts "    }"
+      @f.puts "  }"
+      @f.puts "}"
+      @f.puts
+    end
+
+    @f.puts "extern {"
+    @f.puts "fn malloc(size: usize) -> *mut c_void;", ""
+    @f.puts "fn free(p: *mut c_void);", ""
+    for_each_fun do |f|
+      @f.print "pub ", rust_ffi_proto(f), ";\n"
+    end
+    @f.puts "}"
+    @f.close
+  end
+
+def generate_api
+    @f = File.open(@path + @api_file, 'w')
+    @f.puts <<-EOF
+#![allow(unused)]
+use ffi::{self, ToAPI, ToFFI};
+use std::os::raw::{c_float, c_double, c_int, c_void};
+
 EOF
 
     build_constants
     build_enums
 
-    build_structs_generic do |field, type|
-      type = @types[type]
-      "#{field}: #{rust_typename(type)}"
+    for_each_struct do |x|
+      @f.puts "#[derive(Clone, Debug, PartialEq, PartialOrd)]"
+      build_struct_generic(x) do |type|
+        rust_api_typename(type)
+      end
     end
 
-    @f.puts "extern {"
-    @f.puts "fn free(p: *mut c_void);", ""
     for_each_fun do |f|
-      @f.print "pub ", rust_proto(f), ";\n"
+      @f.print "pub ", rust_api_proto(f)
+      args = f.args.map { |arg| "#{arg.name}.to_ffi()" }.join(", ")
+      print_body "  unsafe { ffi::#{f.name}(#{args}).to_api() }"
     end
-    @f.puts "}", ""
+
     for_each_user_fun do |f|
       @f.puts"#[no_mangle]"
-      @f.print "pub unsafe extern \"C\" ", rust_proto(f)
-      args = f.args.map { |arg| arg.name }.join(", ")
-      print_body "  super::#{f.name}(#{args})"
+      @f.print "pub unsafe extern \"C\" ", rust_ffi_proto(f)
+      args = f.args.map { |arg| "&#{arg.name}.to_api()" }.join(", ")
+      print_body "  super::#{f.name}(#{args}).to_ffi()"
     end
     @f.close
   end
@@ -140,10 +369,12 @@ EOF
     @f = File.open(@path + @user_file, 'w')
     @f.puts "#![allow(unused)]"
     @f.puts "pub mod api;"
+    @f.puts "mod ffi;"
+    @f.puts
     @f.puts "use api::*;"
     @f.puts "use std::os::raw::{c_double, c_int, c_void};", ""
     for_each_user_fun do |f|
-      @f.print rust_proto(f)
+      @f.print rust_api_proto(f)
       print_body "  // fonction a completer"
     end
     @f.close
@@ -151,6 +382,7 @@ EOF
 
   def generate_makefile
     target = $conf['conf']['player_lib']
+    header_file = $conf['conf']['player_filename'] + ".h"
     @f = File.open(@path + "Makefile", 'w')
     @f.print <<-EOF
 # -*- Makefile -*-
@@ -162,7 +394,7 @@ lib_TARGETS = #{target}
 #{target}-rustcflags = -g
 
 # Evite de toucher a ce qui suit
-#{target}-dists += #{$conf['conf']['player_filename']}.h interface.hh #{@api_file}
+#{target}-dists += #{header_file} interface.hh #{@ffi_file} #{@api_file}
 #{target}-srcs += interface.cc #{@user_file}
 #{target}-ldflags = -fPIC -Wl,--whole-archive
 #{target}-ldlibs  = -Wl,--no-whole-archive -lm -lrt -ldl -lpthread -lstdc++
@@ -175,10 +407,11 @@ include ../includes/rules.mk
 
 
   def build()
-    CCxxFileGeneratorForRust.new.build
+    RustCxxFileGenerator.new.build
 
     @path = Pathname.new($install_path) + "rust"
     @user_file = $conf['conf']['player_filename'] + '.rs'
+    @ffi_file = 'ffi.rs'
     @api_file = 'api.rs'
 
     header_generator = CFileGenerator.new
@@ -187,6 +420,7 @@ include ../includes/rules.mk
 
     header_generator.generate_header
     generate_user
+    generate_ffi
     generate_api
     generate_makefile
   end

--- a/tools/generator/test/champions/prologin.rs
+++ b/tools/generator/test/champions/prologin.rs
@@ -1,131 +1,56 @@
-#![allow(bad_style, unused)]
+#![allow(unused)]
 pub mod api;
+mod ffi;
+
 use api::*;
 use std::os::raw::{c_double, c_int, c_void};
-use std::slice::from_raw_parts;
 
 /// Called 10K times to test if things work well.
-unsafe fn test()
+fn test()
 {
     assert!(CONST_VAL/4 == 10);
     assert!(CONST_DOUBLE_2/2. == 668.5);
 
-    send_me_42(42);
-    send_me_42_and_1337(42, 1337);
-    send_me_true(true);
-    send_me_tau(6.2831853);
+    send_me_42(&42);
+    send_me_42_and_1337(&42, &1337);
+    send_me_true(&true);
+    send_me_tau(&6.2831853);
     assert!(returns_42() == 42);
     assert!(returns_true() == true);
     assert!((returns_tau() - 6.2831).abs() < 0.001);
 
-    let r = returns_range(1, 100);
-    {
-        let rs = from_raw_parts(r.ptr, r.len);
-        for i in 1..100 {
-            assert!(rs[i - 1] == i as i32);
-        }
-    }
-    r.free();
+    let r = returns_range(&1, &100);
+    assert!(r == (1..100).collect::<Vec<c_int>>());
 
-    let r = returns_range(1, 10000);
-    {
-        let rs = from_raw_parts(r.ptr, r.len);
-        for i in 1..10000 {
-            assert!(rs[i - 1] == i as i32);
-        }
-    }
-    r.free();
+    let r = returns_range(&1, &10000);
+    assert!(r == (1..10000).collect::<Vec<c_int>>());
 
-    let vr = vec![1, 3, 2, 4, 5, 7, 6];
-    let v = Array {
-        ptr: vr.as_ptr(),
-        len: vr.len(),
-    };
-    let v = returns_sorted(v);
-    {
-        let vs = from_raw_parts(v.ptr, v.len);
-        for i in 0..7 {
-            assert!(vs[i] == (i + 1) as i32);
-        }
-    }
-    v.free();
+    let v = returns_sorted(&vec![1, 3, 2, 4, 5, 7, 6]);
+    assert!(v == (1..8).collect::<Vec<c_int>>());
 
-    {
-        let sr = vec![42; 42];
-        let ss = vec![SimpleStruct {
+    let s = StructWithArray {
+        field_int: 42,
+        field_int_arr: vec![42; 42],
+        field_str_arr: vec![SimpleStruct {
             field_i: 42,
             field_bool: true,
             field_double: 42.42,
+        }; 42],
+    };
+    send_me_42s(&s);
+
+    send_me_test_enum(&TestEnum::Val1, &TestEnum::Val2);
+
+    let l = vec![StructWithArray {
+            field_int: 42,
+            field_int_arr: vec![42; 42],
+            field_str_arr: vec![SimpleStruct {
+                field_i: 42,
+                field_bool: true,
+                field_double: 42.42,
+            }; 42],
         }; 42];
-        let s = StructWithArray {
-            field_int: 42,
-            field_int_arr: Array {
-                ptr: sr.as_ptr(),
-                len: sr.len(),
-            },
-            field_str_arr: Array {
-                ptr: ss.as_ptr(),
-                len: ss.len(),
-            },
-        };
-        send_me_42s(s);
-    }
 
-    send_me_test_enum(TestEnum::Val1, TestEnum::Val2);
-
-    let vi = (0..42).map(|_| vec![42; 42]).collect::<Vec<_>>();
-    let vs = (0..42).map(|_| {
-        (0..42).map(|_| SimpleStruct {
-            field_i: 42,
-            field_bool: true,
-            field_double: 42.42,
-        }).collect::<Vec<_>>()
-    }).collect::<Vec<_>>();
-
-    let l = (0..42).map(|i| {
-        StructWithArray {
-            field_int: 42,
-            field_int_arr: Array {
-                ptr: vi[i].as_ptr(),
-                len: vi[i].len(),
-            },
-            field_str_arr: Array {
-                ptr: vs[i].as_ptr(),
-                len: vs[i].len(),
-            },
-        }
-    }).collect::<Vec<_>>();
-    let ll = Array {
-        ptr: l.as_ptr(),
-        len: l.len(),
-    };
-    let ll = send_me_struct_array(ll);
-    assert!(ll.len == 42);
-    {
-        let lls = from_raw_parts(ll.ptr, ll.len);
-
-        for l in lls
-        {
-            assert!(l.field_int == 42);
-            assert!(l.field_int_arr.len == 42);
-            assert!(l.field_str_arr.len == 42);
-            {
-                let is = from_raw_parts(l.field_int_arr.ptr, l.field_int_arr.len);
-                let ss = from_raw_parts(l.field_str_arr.ptr, l.field_str_arr.len);
-                for &i in is {
-                    assert!(i == 42);
-                }
-                for s in ss
-                {
-                    assert!(s.field_i == 42);
-                    assert!(s.field_bool == true);
-                    assert!(s.field_double == 42.42);
-                }
-            }
-            l.clone().field_int_arr.free();
-            l.clone().field_str_arr.free();
-        }
-    }
-    ll.free();
-
+    let lr = send_me_struct_array(&l);
+    assert!(l == lr);
 }


### PR DESCRIPTION
As discussed in #37.

This doesn't yet eliminate the C layer, because it seems very difficult 
to allocate and construct in C++ a `Vec<T>` (its layout is unspecified so
that its fields can be reordered by rustc, and it is incompatible with malloced
buffers), but all these horrible `Array<T>` are now hidden in a new `ffi`
module.

Nevertheless, this greatly simplifies the API usage, as seen in the
`prologin.rs` test, even if it is not the cleanest solution with regards
to the internal implementation of the FFI.

cc @seirl @Namarand.
