### PR TITLE
Api and GameState interface refactor

### DIFF
--- a/games/tictactoe/src/action_play.cc
+++ b/games/tictactoe/src/action_play.cc
@@ -14,8 +14,8 @@ int ActionPlay::check(const GameState& st) const
     return OK;
 }
 
-void ActionPlay::apply(GameState& st) const
+void ActionPlay::apply_on(GameState* st) const
 {
-    st.set_cell(pos_, player_id_);
-    st.set_player_turn(player_id_, false);
+    st->set_cell(pos_, player_id_);
+    st->set_player_turn(player_id_, false);
 }

--- a/games/tictactoe/src/action_play.hh
+++ b/games/tictactoe/src/action_play.hh
@@ -16,7 +16,9 @@ public:
     ActionPlay() {} // for register_action()
 
     int check(const GameState& st) const override;
-    void apply(GameState& st) const override;
+    void apply_on(GameState* st) const override;
+    // Unhide base class apply()
+    using rules::Action<GameState>::apply;
 
     void handle_buffer(utils::Buffer& buf) override
     {

--- a/games/tictactoe/src/api.cc
+++ b/games/tictactoe/src/api.cc
@@ -2,17 +2,13 @@
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
 #include <stdlib.h>
 
+#include <memory>
+
 #include "actions.hh"
 #include "api.hh"
 
 // global used in interface.cc
 Api* api;
-
-Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
-    : game_state_(std::move(game_state)), player_(player)
-{
-    api = this;
-}
 
 /// Play at the given position
 error Api::play(position pos)
@@ -20,12 +16,12 @@ error Api::play(position pos)
     auto action = std::make_shared<ActionPlay>(pos, player_->id);
 
     error err;
-    if ((err = static_cast<error>(action->check(*game_state_))) != OK)
+    if ((err = static_cast<error>(action->check(game_state()))) != OK)
         return err;
 
     actions_.add(action);
     game_state_.save();
-    action->apply(*game_state_);
+    action->apply(game_state());
     return OK;
 }
 
@@ -38,7 +34,7 @@ int Api::my_team()
 /// Returns the TicTacToe board
 std::vector<int> Api::board()
 {
-    return game_state_->get_board();
+    return game_state().get_board();
 }
 
 /// Cancels the last played action

--- a/games/tictactoe/src/api.cc
+++ b/games/tictactoe/src/api.cc
@@ -10,18 +10,24 @@
 // global used in interface.cc
 Api* api;
 
+Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+    : rules::Api<GameState>(std::move(game_state), player)
+{
+    api = this;
+}
+
 /// Play at the given position
 error Api::play(position pos)
 {
     auto action = std::make_shared<ActionPlay>(pos, player_->id);
 
     error err;
-    if ((err = static_cast<error>(action->check(game_state()))) != OK)
+    if ((err = static_cast<error>(game_state_check(action))) != OK)
         return err;
 
     actions_.add(action);
-    game_state_.save();
-    action->apply(game_state());
+    game_state_save();
+    game_state_apply(action);
     return OK;
 }
 
@@ -35,14 +41,4 @@ int Api::my_team()
 std::vector<int> Api::board()
 {
     return game_state().get_board();
-}
-
-/// Cancels the last played action
-bool Api::cancel()
-{
-    if (!game_state_.can_cancel())
-        return false;
-    actions_.cancel();
-    game_state_.cancel();
-    return true;
 }

--- a/games/tictactoe/src/api.cc
+++ b/games/tictactoe/src/api.cc
@@ -11,24 +11,9 @@
 Api* api;
 
 Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
-    : rules::Api<GameState>(std::move(game_state), player)
+    : rules::Api<GameState, error>(std::move(game_state), player), play(this)
 {
     api = this;
-}
-
-/// Play at the given position
-error Api::play(position pos)
-{
-    auto action = std::make_shared<ActionPlay>(pos, player_->id);
-
-    error err;
-    if ((err = static_cast<error>(game_state_check(action))) != OK)
-        return err;
-
-    actions_.add(action);
-    game_state_save();
-    game_state_apply(action);
-    return OK;
 }
 
 /// Returns your team number

--- a/games/tictactoe/src/api.hh
+++ b/games/tictactoe/src/api.hh
@@ -10,10 +10,6 @@
 #include "constant.hh"
 #include "game_state.hh"
 
-class Api;
-
-extern Api* api;
-
 /*!
 ** The methods of this class are exported through 'interface.cc'
 ** to be called by the clients
@@ -21,11 +17,7 @@ extern Api* api;
 class Api : public rules::Api<GameState>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
-        : rules::Api<GameState>(std::move(game_state), player)
-    {
-        api = this;
-    }
+    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
 
     /// Play at the given position
     error play(position pos);
@@ -35,7 +27,4 @@ public:
 
     /// Returns the TicTacToe board
     std::vector<int> board();
-
-    /// Cancels the last played action
-    bool cancel();
 };

--- a/games/tictactoe/src/api.hh
+++ b/games/tictactoe/src/api.hh
@@ -2,43 +2,31 @@
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
 #pragma once
 
-#include <memory>
 #include <vector>
 
-#include <rules/actions.hh>
-#include <rules/game-state-history.hh>
-#include <rules/game-state.hh>
+#include <rules/api.hh>
 #include <rules/player.hh>
 
 #include "constant.hh"
 #include "game_state.hh"
 
+class Api;
+
+extern Api* api;
+
 /*!
 ** The methods of this class are exported through 'interface.cc'
 ** to be called by the clients
 */
-class Api
+class Api : public rules::Api<GameState>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
-    virtual ~Api() {}
+    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+        : rules::Api<GameState>(std::move(game_state), player)
+    {
+        api = this;
+    }
 
-    const rules::Player_sptr player() const { return player_; }
-    void player_set(rules::Player_sptr player) { player_ = player; }
-
-    void apply_action(rules::IAction_sptr action);
-    rules::Actions* actions() { return &actions_; }
-
-    GameState& game_state() { return *game_state_; }
-    const GameState& game_state() const { return *game_state_; }
-    void clear_old_game_states() { game_state_.clear_old_versions(); }
-
-private:
-    rules::GameStateHistory<GameState> game_state_;
-    rules::Player_sptr player_;
-    rules::Actions actions_;
-
-public:
     /// Play at the given position
     error play(position pos);
 

--- a/games/tictactoe/src/api.hh
+++ b/games/tictactoe/src/api.hh
@@ -7,6 +7,7 @@
 #include <rules/api.hh>
 #include <rules/player.hh>
 
+#include "actions.hh"
 #include "constant.hh"
 #include "game_state.hh"
 
@@ -14,13 +15,13 @@
 ** The methods of this class are exported through 'interface.cc'
 ** to be called by the clients
 */
-class Api : public rules::Api<GameState>
+class Api final : public rules::Api<GameState, error>
 {
 public:
     Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
 
     /// Play at the given position
-    error play(position pos);
+    ApiActionFunc<ActionPlay> play;
 
     /// Returns your team number
     int my_team();

--- a/games/tictactoe/src/game_state.cc
+++ b/games/tictactoe/src/game_state.cc
@@ -3,8 +3,7 @@
 #include "game_state.hh"
 
 GameState::GameState(rules::Players_sptr players)
-    : rules::GameState()
-    , players_(players)
+    : players_(players)
     , board_({NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER,
               NO_PLAYER, NO_PLAYER, NO_PLAYER})
 {

--- a/games/tictactoe/src/rules.cc
+++ b/games/tictactoe/src/rules.cc
@@ -123,7 +123,12 @@ bool Rules::is_finished()
     return st.winner() != st.NO_PLAYER || is_full;
 }
 
-GameState& Rules::game_state() const
+GameState& Rules::game_state()
+{
+    return api_->game_state();
+}
+
+const GameState& Rules::game_state() const
 {
     return api_->game_state();
 }

--- a/games/tictactoe/src/rules.cc
+++ b/games/tictactoe/src/rules.cc
@@ -40,12 +40,12 @@ void Rules::apply_action(const rules::IAction_sptr& action)
     // client/server desynchronizations and make sure the gamestate is always
     // consistent across the clients and the server.
 
-    int err = action->check(api_->game_state());
+    int err = api_->game_state_check(action);
     if (err)
         FATAL("Synchronization error: received action %d from player %d, but "
               "check() on current gamestate returned %d.",
               action->id(), action->player_id(), err);
-    action->apply(api_->game_state());
+    api_->game_state_apply(action);
 }
 
 void Rules::at_player_start(rules::ClientMessenger_sptr)

--- a/games/tictactoe/src/rules.hh
+++ b/games/tictactoe/src/rules.hh
@@ -40,7 +40,8 @@ public:
 
     bool is_finished() override;
 
-    GameState& game_state() const;
+    GameState& game_state();
+    const GameState& game_state() const;
 
 protected:
     f_champion_init_game champion_init_game_;

--- a/games/tictactoe/src/tests/test-action_play.cc
+++ b/games/tictactoe/src/tests/test-action_play.cc
@@ -25,7 +25,7 @@ TEST_F(ActionTest, ActionPlay_AlreadyOccupied)
     ActionPlay act(pos, PLAYER_1);
     EXPECT_EQ(OK, act.check(*st));
 
-    act.apply(*st);
+    act.apply(st);
     EXPECT_EQ(PLAYER_1, st->get_cell(pos));
 
     ActionPlay act2(pos, PLAYER_1);
@@ -43,7 +43,7 @@ TEST_F(ActionTest, ActionPlay_AlreadyPlayed)
 
     ActionPlay act({0, 0}, PLAYER_1);
     EXPECT_EQ(OK, act.check(*st));
-    act.apply(*st);
+    act.apply(st);
 
     ActionPlay act2({1, 1}, PLAYER_1);
     EXPECT_EQ(ALREADY_PLAYED, act2.check(*st));
@@ -57,12 +57,12 @@ TEST_F(ActionTest, ActionPlay_Ok)
     ActionPlay act({0, 0}, PLAYER_1);
     EXPECT_EQ(OK, act.check(*st));
     EXPECT_EQ(st->NO_PLAYER, st->get_cell({0, 0}));
-    act.apply(*st);
+    act.apply(st);
     EXPECT_EQ(PLAYER_1, st->get_cell({0, 0}));
 
     ActionPlay act2({2, 2}, PLAYER_2);
     EXPECT_EQ(OK, act2.check(*st));
     EXPECT_EQ(st->NO_PLAYER, st->get_cell({2, 2}));
-    act2.apply(*st);
+    act2.apply(st);
     EXPECT_EQ(PLAYER_2, st->get_cell({2, 2}));
 }

--- a/games/tictactoe/src/tests/test-api.cc
+++ b/games/tictactoe/src/tests/test-api.cc
@@ -21,13 +21,13 @@ TEST_F(ApiTest, Api_Board)
         player.api->game_state().set_player_turn(player.id, true);
         if (player.id == PLAYER_1)
         {
-            EXPECT_EQ(OK, player.api->play({0, 0}));
+            EXPECT_EQ(OK, player.api->play(position{0, 0}));
             board = player.api->board();
             EXPECT_EQ(board[0], PLAYER_1);
         }
         else
         {
-            EXPECT_EQ(OK, player.api->play({1, 1}));
+            EXPECT_EQ(OK, player.api->play(position{1, 1}));
             board = player.api->board();
             EXPECT_EQ(board[4], PLAYER_2);
         }
@@ -41,7 +41,7 @@ TEST_F(ApiTest, Api_Cancel)
         EXPECT_FALSE(player.api->cancel());
         player.api->game_state().set_player_turn(player.id, true);
 
-        EXPECT_EQ(OK, player.api->play({0, 0}));
+        EXPECT_EQ(OK, player.api->play(position{0, 0}));
         EXPECT_EQ(player.id, player.api->board()[0]);
 
         EXPECT_TRUE(player.api->cancel());

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -44,15 +44,18 @@ public:
 template <typename TState>
 class Action : public IAction
 {
+    static_assert(std::is_base_of<rules::GameState, TState>::value,
+                  "TState not derived from rules::GameState");
+
 public:
     virtual int check(const TState& st) const = 0;
     int check(const GameState& st) const override
     {
-        return check(dynamic_cast<const TState&>(st));
+        return check(static_cast<const TState&>(st));
     }
 
     virtual void apply_on(TState* st) const = 0;
-    void apply(GameState* st) const { apply_on(dynamic_cast<TState*>(st)); }
+    void apply(GameState* st) const { apply_on(static_cast<TState*>(st)); }
     void apply(std::unique_ptr<TState>& st) const { apply_on(st.get()); }
 };
 

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -8,8 +8,6 @@
 
 #include <utils/buffer.hh>
 
-#include "game-state.hh"
-
 namespace rules {
 
 class GameState;
@@ -26,7 +24,7 @@ public:
     virtual int check(const GameState& st) const = 0;
 
     // Apply action to game state.
-    virtual void apply(GameState& st) const = 0;
+    virtual void apply(GameState* st) const = 0;
 
     // Handles serialization and deserialization of the Action object to a
     // buffer.
@@ -53,11 +51,9 @@ public:
         return check(dynamic_cast<const TState&>(st));
     }
 
-    virtual void apply(TState& st) const = 0;
-    void apply(GameState& st) const override
-    {
-        apply(dynamic_cast<TState&>(st));
-    }
+    virtual void apply_on(TState* st) const = 0;
+    void apply(GameState* st) const { apply_on(dynamic_cast<TState*>(st)); }
+    void apply(std::unique_ptr<TState>& st) const { apply_on(st.get()); }
 };
 
 using IAction_sptr = std::shared_ptr<IAction>;

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -12,6 +12,8 @@
 
 namespace rules {
 
+class GameState;
+
 // Interface to be implemented by all action types.
 class IAction
 {

--- a/src/lib/rules/api.hh
+++ b/src/lib/rules/api.hh
@@ -6,6 +6,7 @@
 
 #include "actions.hh"
 #include "game-state-history.hh"
+#include "player.hh"
 
 namespace rules {
 

--- a/src/lib/rules/api.hh
+++ b/src/lib/rules/api.hh
@@ -21,12 +21,32 @@ public:
     const Player_sptr player() const { return player_; }
     void player_set(Player_sptr player) { player_ = player; }
 
-    void apply_action(IAction_sptr action);
     Actions* actions() { return &actions_; }
 
     GameState& game_state() { return *game_state_; }
     const GameState& game_state() const { return *game_state_; }
+
+    // Checks action on GameState
+    int game_state_check(IAction_sptr action) const
+    {
+        return game_state_->check(action);
+    }
+
+    // Applies action to GameState
+    void game_state_apply(IAction_sptr action) { game_state_->apply(action); }
+
+    void game_state_save() { game_state_.save(); }
     void clear_old_game_states() { game_state_.clear_old_versions(); }
+
+    // Cancels the last played action
+    bool cancel()
+    {
+        if (!game_state_.can_cancel())
+            return false;
+        actions_.cancel();
+        game_state_.cancel();
+        return true;
+    }
 
 protected:
     GameStateHistory<GameState> game_state_;

--- a/src/lib/rules/api.hh
+++ b/src/lib/rules/api.hh
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2019 Association Prologin <association@prologin.org>
+#pragma once
+
+#include <memory>
+
+#include "actions.hh"
+#include "game-state-history.hh"
+
+namespace rules {
+
+template <typename GameState>
+class Api
+{
+public:
+    Api(std::unique_ptr<GameState> game_state, Player_sptr player)
+        : game_state_(std::move(game_state)), player_(player)
+    {}
+    virtual ~Api() {}
+
+    const Player_sptr player() const { return player_; }
+    void player_set(Player_sptr player) { player_ = player; }
+
+    void apply_action(IAction_sptr action);
+    Actions* actions() { return &actions_; }
+
+    GameState& game_state() { return *game_state_; }
+    const GameState& game_state() const { return *game_state_; }
+    void clear_old_game_states() { game_state_.clear_old_versions(); }
+
+protected:
+    GameStateHistory<GameState> game_state_;
+    Player_sptr player_;
+    Actions actions_;
+};
+
+} // namespace rules

--- a/src/lib/rules/game-state.hh
+++ b/src/lib/rules/game-state.hh
@@ -2,6 +2,8 @@
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
 #pragma once
 
+#include "action.hh"
+
 namespace rules {
 
 class GameState
@@ -12,6 +14,9 @@ public:
 
     // Explicit copy of the game state
     virtual GameState* copy() const = 0;
+
+    int check(IAction_sptr action) const { return action->check(*this); }
+    void apply(IAction_sptr action) { action->apply(*this); }
 
 protected:
     // Protected to be called by copy()

--- a/src/lib/rules/game-state.hh
+++ b/src/lib/rules/game-state.hh
@@ -16,7 +16,7 @@ public:
     virtual GameState* copy() const = 0;
 
     int check(IAction_sptr action) const { return action->check(*this); }
-    void apply(IAction_sptr action) { action->apply(*this); }
+    void apply(IAction_sptr action) { action->apply(this); }
 
 protected:
     // Protected to be called by copy()

--- a/src/lib/rules/tests/test-action.cc
+++ b/src/lib/rules/tests/test-action.cc
@@ -30,7 +30,7 @@ public:
             return 0;
     }
 
-    void apply(MyGameState& st) const override { st.x += 1; }
+    void apply_on(MyGameState* st) const override { st->x += 1; }
 
     void handle_buffer(utils::Buffer&) override {}
 
@@ -52,7 +52,7 @@ public:
             return 0;
     }
 
-    void apply(MyGameState& st) const override { st.x -= 1; }
+    void apply_on(MyGameState* st) const override { st->x -= 1; }
 
     void handle_buffer(utils::Buffer&) override {}
 
@@ -69,13 +69,13 @@ TEST(RulesAction, CheckApply)
     MyIncrAction incr;
     MyDecrAction decr;
 
-    incr.apply(mgs);
+    incr.apply(&mgs);
     EXPECT_EQ(1, mgs.x);
 
-    incr.apply(mgs);
+    incr.apply(&mgs);
     EXPECT_EQ(2, mgs.x);
 
-    decr.apply(mgs);
+    decr.apply(&mgs);
     EXPECT_EQ(1, mgs.x);
 }
 
@@ -89,7 +89,7 @@ TEST(RulesAction, CheckError)
     EXPECT_NE(0, decr.check(mgs));
 
     for (int i = 0; i < 3; ++i)
-        incr.apply(mgs);
+        incr.apply(&mgs);
 
     EXPECT_NE(0, incr.check(mgs));
 }

--- a/tools/generator/files/api.cc
+++ b/tools/generator/files/api.cc
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
+#include "api.hh"
+
 #include <stdlib.h>
 
 #include "actions.hh"
-#include "api.hh"
 
 // global used in interface.cc
 Api* api;
 
 Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
-    : game_state_(std::move(game_state)), player_(player)
+  : rules::Api<GameState>(std::move(game_state), player_(player)
 {
     api = this;
 }

--- a/tools/generator/files/api.hh
+++ b/tools/generator/files/api.hh
@@ -6,9 +6,7 @@
 #include <vector>
 
 #include <rules/actions.hh>
-#include <rules/game-state.hh>
 #include <rules/player.hh>
-#include <utils/versioned_ptr.hh>
 
 #include "constant.hh"
 #include "game_state.hh"
@@ -23,20 +21,5 @@ public:
     Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
     virtual ~Api() {}
 
-    const rules::Player_sptr player() const { return player_; }
-    void player_set(rules::Player_sptr player) { player_ = player; }
-
-    rules::Actions* actions() { return &actions_; }
-
-    const GameState& game_state() const { return game_state_; }
-    GameState& game_state() { return game_state_; }
-    void clear_old_game_states() { game_state_.clear_old_versions(); }
-
-private:
-    utils::VersionedPtr<GameState> game_state_;
-    rules::Player_sptr player_;
-    rules::Actions actions_;
-
-public:
     // @@GEN_HERE@@
 };


### PR DESCRIPTION
This PR builds on top of the changes in #53 and is intended to reduce the amount of boilerplate code in the games.

It moves the code of the `Api` class that was generated to a new `rules::Api` class that has the same functionality. This provides a `Api::cancel()` method to all game Apis, but games do not have to export it.

The next refactor in line is to probably to check whether we need really need an `Api` class and if `Rules` should not own the GameState.