### PR TITLE
Socket returns std::unique_ptr<utils::Buffer> instead of utils::Buffer*

### DIFF
--- a/src/lib/net/client-socket.cc
+++ b/src/lib/net/client-socket.cc
@@ -62,7 +62,7 @@ void ClientSocket::close()
     }
 }
 
-utils::Buffer* ClientSocket::pull(int flags)
+std::unique_ptr<utils::Buffer> ClientSocket::pull(int flags)
 {
     return recv_sckt(pubsub_sckt_, flags);
 }

--- a/src/lib/net/client-socket.hh
+++ b/src/lib/net/client-socket.hh
@@ -21,7 +21,7 @@ public:
     void init() override;
     void close() override;
 
-    utils::Buffer* pull(int flags = 0);
+    std::unique_ptr<utils::Buffer> pull(int flags = 0);
 };
 
 using ClientSocket_sptr = std::shared_ptr<ClientSocket>;

--- a/src/lib/net/socket.cc
+++ b/src/lib/net/socket.cc
@@ -36,7 +36,7 @@ bool Socket::send(const utils::Buffer& msg, int flags)
     return send_sckt(msg, reqrep_sckt_, flags);
 }
 
-utils::Buffer* Socket::recv(int flags)
+std::unique_ptr<utils::Buffer> Socket::recv(int flags)
 {
     return recv_sckt(reqrep_sckt_, flags);
 }
@@ -77,7 +77,8 @@ bool Socket::send_sckt(const utils::Buffer& buf,
     }
 }
 
-utils::Buffer* Socket::recv_sckt(std::shared_ptr<zmq::socket_t> sckt, int flags)
+std::unique_ptr<utils::Buffer>
+Socket::recv_sckt(std::shared_ptr<zmq::socket_t> sckt, int flags)
 {
     try
     {
@@ -100,9 +101,7 @@ utils::Buffer* Socket::recv_sckt(std::shared_ptr<zmq::socket_t> sckt, int flags)
         data.assign(reinterpret_cast<uint8_t*>(zmsg.data()),
                     reinterpret_cast<uint8_t*>(zmsg.data()) + zmsg.size());
 
-        utils::Buffer* buf = new utils::Buffer(data);
-
-        return buf;
+        return std::make_unique<utils::Buffer>(data);
     }
     catch (const std::exception& e)
     {

--- a/src/lib/net/socket.hh
+++ b/src/lib/net/socket.hh
@@ -29,15 +29,15 @@ public:
 
     virtual void init() { shared_init(); }
     virtual bool send(const utils::Buffer& msg, int flags = 0);
-    virtual utils::Buffer* recv(int flags = 0);
+    virtual std::unique_ptr<utils::Buffer> recv(int flags = 0);
     virtual bool poll(long timeout);
     virtual void close() = 0;
 
 protected:
     bool send_sckt(const utils::Buffer& buf,
                    std::shared_ptr<zmq::socket_t> sckt, int flags);
-    // recv_sckt allocates a Message, it has to be deleted after its use
-    utils::Buffer* recv_sckt(std::shared_ptr<zmq::socket_t> sckt, int flags);
+    std::unique_ptr<utils::Buffer>
+    recv_sckt(std::shared_ptr<zmq::socket_t> sckt, int flags);
 
 protected:
     // Must be called by subclasses after custom initialization.

--- a/src/lib/rules/client-messenger.cc
+++ b/src/lib/rules/client-messenger.cc
@@ -32,9 +32,9 @@ void ClientMessenger::send_actions(Actions& actions)
     send(buf);
 }
 
-utils::Buffer* ClientMessenger::recv()
+std::unique_ptr<utils::Buffer> ClientMessenger::recv()
 {
-    utils::Buffer* buf = sckt_->recv();
+    auto buf = sckt_->recv();
     if (!buf)
         FATAL("Unable to receive message from server");
 
@@ -44,9 +44,9 @@ utils::Buffer* ClientMessenger::recv()
     return buf;
 }
 
-utils::Buffer* ClientMessenger::pull()
+std::unique_ptr<utils::Buffer> ClientMessenger::pull()
 {
-    utils::Buffer* buf = sckt_->pull();
+    auto buf = sckt_->pull();
 
     net::Message msg;
     msg.handle_buffer(*buf);
@@ -56,16 +56,12 @@ utils::Buffer* ClientMessenger::pull()
 
 void ClientMessenger::pull_actions(Actions* actions)
 {
-    utils::Buffer* buf = pull();
-    actions->handle_buffer(*buf);
-    delete buf;
+    actions->handle_buffer(*pull());
 }
 
 void ClientMessenger::pull_id(uint32_t* id)
 {
-    utils::Buffer* buf = pull();
-    buf->handle(*id);
-    delete buf;
+    pull()->handle(*id);
 }
 
 void ClientMessenger::ack()
@@ -81,7 +77,7 @@ void ClientMessenger::ack()
 
 void ClientMessenger::wait_for_ack()
 {
-    utils::Buffer* buf = sckt_->recv();
+    auto buf = sckt_->recv();
     if (!buf)
         FATAL("Unable to receive ack from server");
 

--- a/src/lib/rules/client-messenger.hh
+++ b/src/lib/rules/client-messenger.hh
@@ -28,9 +28,9 @@ public:
     void send(const utils::Buffer&) override;
     void send_actions(Actions&);
 
-    utils::Buffer* recv() override;
+    std::unique_ptr<utils::Buffer> recv() override;
 
-    utils::Buffer* pull();
+    std::unique_ptr<utils::Buffer> pull();
     void pull_actions(Actions*);
     void pull_id(uint32_t*);
 

--- a/src/lib/rules/messenger.hh
+++ b/src/lib/rules/messenger.hh
@@ -15,7 +15,7 @@ public:
     virtual ~Messenger();
 
     virtual void send(const utils::Buffer&) = 0;
-    virtual utils::Buffer* recv() = 0;
+    virtual std::unique_ptr<utils::Buffer> recv() = 0;
 };
 
 } // namespace rules

--- a/src/lib/rules/server-messenger.cc
+++ b/src/lib/rules/server-messenger.cc
@@ -53,9 +53,9 @@ void ServerMessenger::push_id(uint32_t id)
     push(buf);
 }
 
-utils::Buffer* ServerMessenger::recv()
+std::unique_ptr<utils::Buffer> ServerMessenger::recv()
 {
-    utils::Buffer* buf = sckt_->recv();
+    auto buf = sckt_->recv();
     if (!buf)
         FATAL("Unable to receive data from client");
 
@@ -70,11 +70,7 @@ utils::Buffer* ServerMessenger::recv()
 
 void ServerMessenger::recv_actions(Actions* actions)
 {
-    utils::Buffer* buf = recv();
-
-    actions->handle_buffer(*buf);
-
-    delete buf;
+    actions->handle_buffer(*recv());
 }
 
 void ServerMessenger::ack()
@@ -90,7 +86,7 @@ void ServerMessenger::ack()
 
 void ServerMessenger::wait_for_ack()
 {
-    utils::Buffer* buf = sckt_->recv();
+    auto buf = sckt_->recv();
     if (!buf)
         FATAL("Unable to receive ack from client");
 

--- a/src/lib/rules/server-messenger.hh
+++ b/src/lib/rules/server-messenger.hh
@@ -26,7 +26,7 @@ public:
 
     void send(const utils::Buffer&) override;
 
-    utils::Buffer* recv() override;
+    std::unique_ptr<utils::Buffer> recv() override;
     void recv_actions(Actions* actions);
 
     bool poll(long timeout);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -127,9 +127,9 @@ void Server::wait_for_players()
     while (players_->size() + spectators_->size() <
            static_cast<size_t>(FLAGS_nb_clients))
     {
-        utils::Buffer* buf_req = nullptr;
+        auto buf_req = sckt_->recv();
 
-        if (!(buf_req = sckt_->recv()))
+        if (!buf_req)
             continue;
 
         net::Message id_req;
@@ -167,8 +167,6 @@ void Server::wait_for_players()
         rules::Player_sptr new_player =
             rules::Player_sptr(new rules::Player(player_id, player_type));
         buf_req->handle(new_player->name);
-
-        delete buf_req;
 
         // Send the reply with a uid
         net::Message id_rep(net::MSG_CONNECT, new_player->id);


### PR DESCRIPTION
Fixes memory leak in ClientMessenger::wait_for_ack()