### PR TITLE
Buffer in buffer

### DIFF
--- a/src/lib/rules/actions.hh
+++ b/src/lib/rules/actions.hh
@@ -14,7 +14,7 @@
 
 namespace rules {
 
-class Actions
+class Actions : public utils::IBufferizable
 {
 public:
     static constexpr size_t MAX_ACTIONS = 1024;
@@ -24,7 +24,7 @@ public:
     void register_action(uint32_t action_id, ActionFactory action_factory);
 
     // Serialization/Unserialization
-    void handle_buffer(utils::Buffer& buf);
+    void handle_buffer(utils::Buffer& buf) override;
 
     void add(IAction_sptr action)
     {

--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -34,9 +34,12 @@ struct Player
 
 using Player_sptr = std::shared_ptr<Player>;
 
-struct Players
+struct Players final : utils::IBufferizable
 {
-    void handle_buffer(utils::Buffer& buf)
+    Players() = default;
+    Players(std::vector<Player_sptr> players) : players(players) {}
+
+    void handle_buffer(utils::Buffer& buf) override
     {
         if (buf.serialize())
         {

--- a/src/lib/utils/buffer.hh
+++ b/src/lib/utils/buffer.hh
@@ -175,3 +175,9 @@ private:
 };
 
 } // namespace utils
+
+inline std::ostream& operator<<(std::ostream& os, const utils::Buffer& buf)
+{
+    os.write((char*)buf.data(), buf.size());
+    return os;
+}

--- a/src/lib/utils/buffer.hh
+++ b/src/lib/utils/buffer.hh
@@ -16,6 +16,13 @@
 
 namespace utils {
 
+class Buffer;
+
+struct IBufferizable
+{
+    virtual void handle_buffer(Buffer& buf) = 0;
+};
+
 // Exception raised when a deserialization fails. For example, when the buffer
 // is too small to be deserialized properly.
 struct DeserializationError : public std::runtime_error
@@ -131,6 +138,23 @@ public:
     void handle(T& x)
     {
         handle_mem((char*)&x, sizeof(T));
+    }
+
+    // Handle types of variable lengths
+    void handle_bufferizable(IBufferizable* obj)
+    {
+        utils::Buffer tmp;
+        if (serialize())
+        {
+            obj->handle_buffer(tmp);
+            handle(tmp);
+        }
+        else
+        {
+            handle(tmp);
+            utils::Buffer tmp_des{std::move(tmp)};
+            obj->handle_buffer(tmp_des);
+        }
     }
 
     Buffer& operator+=(const Buffer& b)

--- a/src/lib/utils/tests/test-buffer.cc
+++ b/src/lib/utils/tests/test-buffer.cc
@@ -22,6 +22,13 @@ struct MyStruct
     }
 };
 
+struct MyBufferizable : IBufferizable
+{
+    int x;
+
+    void handle_buffer(Buffer& buf) override { buf.handle(x); };
+};
+
 TEST(UtilsBuffer, Serialize)
 {
     Buffer buf;
@@ -126,4 +133,20 @@ TEST(UtilsBuffer, DeserializeError)
     Buffer buf(v);
     MyStruct s;
     ASSERT_THROW(s.handle_buffer(buf), DeserializationError);
+}
+
+TEST(UtilsBuffer, IBufferizable)
+{
+    MyBufferizable obj;
+    obj.x = 42;
+    Buffer buf_ser;
+
+    buf_ser.handle_bufferizable(&obj);
+
+    EXPECT_EQ(buf_ser.data()[0], sizeof(obj.x));
+
+    MyBufferizable obj2;
+    Buffer buf_des{std::move(buf_ser)};
+    buf_des.handle_bufferizable(&obj2);
+    EXPECT_EQ(obj2.x, 42);
 }


### PR DESCRIPTION
Allow having multiple size-prefixed buffers in a buffer. 

This construct is used to implement the replay files, which are a concatenation of multiple buffers, roughly: map, players, actions*, results.