### PR TITLE
Add stechec2-replay

### DIFF
--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -726,7 +726,7 @@ requires the rules shared library to be present to replay a match::
 The replay file contains the map, if the game uses one, the list of actions
 sent by the clients (champions and spectators) and the final score.  At the end
 of the replayed match, ``stechec2-replay`` checks if the obtained score matches
-the score save in the reply file.
+the score saved in the reply file.
 
 You can use this tool to replay a match that triggers a specific bug, or use
-the replay file a unit test.
+the replay file as a unit test.

--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -707,9 +707,9 @@ And that's it!
 Debugging
 =========
 
-Debugging or testing the rules require starting a server and multiple clients.
+Debugging or testing the rules requires starting a server and multiple clients.
 This process is simplified by the ``stechec2-run`` utility, but it still
-require you to have the champions compiled locally. This setup is not
+requires you to have the champions compiled locally. This setup is not
 straightforward and may not even reproduce a specific bug if the champions
 generate random actions.
 
@@ -723,5 +723,10 @@ requires the rules shared library to be present to replay a match::
 
    stechec2-replay --replay match.replay --rules rules.so
 
-You can use this feature to replay a match that triggers a specific bug, or use
+The replay file contains the map, if the game uses one, the list of actions
+sent by the clients (champions and spectators) and the final score.  At the end
+of the replayed match, ``stechec2-replay`` checks if the obtained score matches
+the score save in the reply file.
+
+You can use this tool to replay a match that triggers a specific bug, or use
 the replay file a unit test.

--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -703,3 +703,25 @@ functions but for round specific needs, such as ``start_of_round``,
 ``end_of_round``, etc.
 
 And that's it!
+
+Debugging
+=========
+
+Debugging or testing the rules require starting a server and multiple clients.
+This process is simplified by the ``stechec2-run`` utility, but it still
+require you to have the champions compiled locally. This setup is not
+straightforward and may not even reproduce a specific bug if the champions
+generate random actions.
+
+To create a standalone copy of a match, you can create a match replay file with
+the ``--replay`` command line argument of ``stechec2-server``::
+
+   stechec2-server --replay match.replay ...
+
+The replay file can be read by the ``stechec2-replay`` utility, which only
+requires the rules shared library to be present to replay a match::
+
+   stechec2-replay --replay match.replay --rules rules.so
+
+You can use this feature to replay a match that triggers a specific bug, or use
+the replay file a unit test.

--- a/games/plusminus/src/entry.cc
+++ b/games/plusminus/src/entry.cc
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <rules/client-messenger.hh>
+#include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>
 
@@ -32,6 +33,11 @@ void rules_result()
 void player_loop(rules::ClientMessenger_sptr msgr)
 {
     rules_->player_loop(msgr);
+}
+
+void replay_loop(rules::ReplayMessenger_sptr msgr)
+{
+    rules_->replay_loop(msgr);
 }
 
 void server_loop(rules::ServerMessenger_sptr msgr)

--- a/games/tictactoe/src/entry.cc
+++ b/games/tictactoe/src/entry.cc
@@ -34,6 +34,11 @@ void player_loop(rules::ClientMessenger_sptr msgr)
     rules_->player_loop(msgr);
 }
 
+void replay_loop(rules::ReplayMessenger_sptr msgr)
+{
+    rules_->replay_loop(msgr);
+}
+
 void server_loop(rules::ServerMessenger_sptr msgr)
 {
     rules_->server_loop(msgr);

--- a/src/lib/rules/options.hh
+++ b/src/lib/rules/options.hh
@@ -42,6 +42,9 @@ struct Options
 
     // Game data dump output stream
     std::shared_ptr<std::ostream> dump_stream;
+
+    // Replay data dump output stream
+    std::shared_ptr<std::ostream> replay_stream;
 };
 
 std::string read_map_from_path(const std::string& path);

--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utils/buffer.hh>
 #include <utility>
@@ -59,6 +60,19 @@ struct Players final : utils::IBufferizable
                 players.push_back(player);
             }
         }
+    }
+
+    std::string scores_yaml() const
+    {
+        std::stringstream ss;
+        for (auto& player : players)
+        {
+            ss << "---" << std::endl
+               << "player: " << player->name.c_str() << std::endl
+               << "score: " << player->score << std::endl
+               << "nb_timeout: " << player->nb_timeout << std::endl;
+        }
+        return ss.str();
     }
 
     size_t size() const { return players.size(); }

--- a/src/lib/rules/replay-messenger.cc
+++ b/src/lib/rules/replay-messenger.cc
@@ -1,0 +1,15 @@
+#include "replay-messenger.hh"
+
+#include "rules/actions.hh"
+
+namespace rules {
+void ReplayMessenger::pull_id(uint32_t* player_id)
+{
+    buf_->handle(*player_id);
+}
+
+void ReplayMessenger::pull_actions(Actions* actions)
+{
+    buf_->handle_bufferizable(actions);
+}
+} // namespace rules

--- a/src/lib/rules/replay-messenger.cc
+++ b/src/lib/rules/replay-messenger.cc
@@ -3,6 +3,7 @@
 #include "rules/actions.hh"
 
 namespace rules {
+
 void ReplayMessenger::pull_id(uint32_t* player_id)
 {
     buf_->handle(*player_id);
@@ -12,4 +13,5 @@ void ReplayMessenger::pull_actions(Actions* actions)
 {
     buf_->handle_bufferizable(actions);
 }
+
 } // namespace rules

--- a/src/lib/rules/replay-messenger.hh
+++ b/src/lib/rules/replay-messenger.hh
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2019 Association Prologin <association@prologin.org>
+#pragma once
+
+#include <rules/messenger.hh>
+
+namespace rules {
+
+class Actions;
+
+class ReplayMessenger
+{
+public:
+    ReplayMessenger(utils::Buffer* buf) : buf_(buf) {}
+
+    void pull_id(uint32_t* player_id);
+    void pull_actions(Actions* actions);
+
+private:
+    utils::Buffer* buf_;
+};
+
+using ReplayMessenger_sptr = std::shared_ptr<ReplayMessenger>;
+
+} // namespace rules

--- a/src/lib/rules/replay-messenger.hh
+++ b/src/lib/rules/replay-messenger.hh
@@ -11,7 +11,7 @@ class Actions;
 class ReplayMessenger
 {
 public:
-    ReplayMessenger(utils::Buffer* buf) : buf_(buf) {}
+    explicit ReplayMessenger(utils::Buffer* buf) : buf_(buf) {}
 
     void pull_id(uint32_t* player_id);
     void pull_actions(Actions* actions);

--- a/src/lib/rules/rules.cc
+++ b/src/lib/rules/rules.cc
@@ -314,37 +314,37 @@ void TurnBasedRules::replay_loop(ReplayMessenger_sptr msgr)
     while (!is_finished())
     {
         start_of_round();
-        for (const auto& p : players_->players)
+        for (const auto& player : players_->players)
         {
-            DEBUG("Turn for player: %d", p->id);
+            DEBUG("Turn for player: %d", player->id);
 
-            start_of_player_turn(p->id);
-            start_of_turn(p->id);
+            start_of_player_turn(player->id);
+            start_of_turn(player->id);
 
             msgr->pull_actions(actions);
             DEBUG("Pulled %d actions", actions->size());
-            for (const auto action : actions->actions())
+            for (const auto& action : actions->actions())
                 apply_action(action);
             actions->clear();
 
-            end_of_player_turn(p->id);
-            end_of_turn(p->id);
+            end_of_player_turn(player->id);
+            end_of_turn(player->id);
 
-            for (const auto& s : spectators_->players)
+            for (const auto& spectator : spectators_->players)
             {
-                DEBUG("Turn for spectator %d", s->id);
+                DEBUG("Turn for spectator %d", spectator->id);
 
-                start_of_spectator_turn(s->id);
-                start_of_turn(s->id);
+                start_of_spectator_turn(spectator->id);
+                start_of_turn(spectator->id);
 
                 msgr->pull_actions(actions);
                 DEBUG("Pulled %d actions", actions->size());
-                for (const auto action : actions->actions())
+                for (const auto& action : actions->actions())
                     apply_action(action);
                 actions->clear();
 
-                end_of_spectator_turn(s->id);
-                end_of_turn(s->id);
+                end_of_spectator_turn(spectator->id);
+                end_of_turn(spectator->id);
             }
         }
         end_of_round();

--- a/src/lib/rules/rules.hh
+++ b/src/lib/rules/rules.hh
@@ -9,6 +9,7 @@
 #include "client-messenger.hh"
 #include "options.hh"
 #include "player.hh"
+#include "replay-messenger.hh"
 #include "server-messenger.hh"
 
 namespace rules {
@@ -25,6 +26,7 @@ public:
     /* Pure virtual methods */
 
     virtual void player_loop(ClientMessenger_sptr msgr) = 0;
+    virtual void replay_loop(ReplayMessenger_sptr msgr) = 0;
     virtual void spectator_loop(ClientMessenger_sptr msgr) = 0;
     virtual void server_loop(ServerMessenger_sptr msgr) = 0;
 
@@ -68,6 +70,10 @@ public:
               "but the server was launched with the `--dump` option.");
     }
 
+    // Called after every turn to save the actions of the player to the replay
+    // file
+    void save_player_actions(Actions* actions);
+
 protected:
     bool is_spectator(uint32_t id);
 
@@ -92,6 +98,7 @@ public:
     ~SynchronousRules() override = default;
 
     void player_loop(ClientMessenger_sptr msgr) final;
+    void replay_loop(ReplayMessenger_sptr msgr) final;
     void spectator_loop(ClientMessenger_sptr msgr) final;
     void server_loop(ServerMessenger_sptr msgr) final;
 };
@@ -113,6 +120,7 @@ public:
     virtual void end_of_spectator_turn(uint32_t) {}
 
     void player_loop(ClientMessenger_sptr msgr) final;
+    void replay_loop(ReplayMessenger_sptr msgr) final;
     void spectator_loop(ClientMessenger_sptr msgr) final;
     void server_loop(ServerMessenger_sptr msgr) final;
 };

--- a/src/lib/rules/types.hh
+++ b/src/lib/rules/types.hh
@@ -4,6 +4,7 @@
 
 #include <rules/client-messenger.hh>
 #include <rules/options.hh>
+#include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 
 namespace rules {
@@ -12,6 +13,7 @@ using f_rules_init = void (*)(const Options&);
 using f_rules_result = void (*)();
 
 using f_client_loop = void (*)(ClientMessenger_sptr);
+using f_replay_loop = void (*)(ReplayMessenger_sptr);
 using f_server_loop = void (*)(ServerMessenger_sptr);
 
 } // namespace rules

--- a/src/replay/main.cc
+++ b/src/replay/main.cc
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2019 Association Prologin <association@prologin.org>
+#include "replay.hh"
+
+#include <gflags/gflags.h>
+
+int main(int argc, char** argv)
+{
+    GFLAGS_NAMESPACE::ParseCommandLineFlags(&argc, &argv, true);
+
+    Replay replay{};
+    if (!replay.check())
+        return EXIT_FAILURE;
+    replay.run();
+    return EXIT_SUCCESS;
+}

--- a/src/replay/replay.cc
+++ b/src/replay/replay.cc
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2012 Association Prologin <association@prologin.org>
+#include "replay.hh"
+
+#include <fstream>
+#include <iterator>
+
+#include <gflags/gflags.h>
+
+#include <rules/replay-messenger.hh>
+#include <utils/log.hh>
+
+DEFINE_string(rules, "", "Rules library");
+DEFINE_string(replay, "", "Replay file");
+
+bool Replay::check() const
+{
+    if (FLAGS_rules.empty())
+    {
+        ERR("--rules cannot be empty");
+        return false;
+    }
+    if (FLAGS_replay.empty())
+    {
+        ERR("--replay cannot be empty");
+        return false;
+    }
+    return true;
+}
+
+void Replay::run()
+{
+    // Get required functions from the rules library
+    auto rules_lib = std::make_unique<utils::DLL>(FLAGS_rules);
+    auto rules_init = rules_lib->get<rules::f_rules_init>("rules_init");
+    auto replay_loop = rules_lib->get<rules::f_replay_loop>("replay_loop");
+    auto rules_result = rules_lib->get<rules::f_rules_result>("rules_result");
+
+    auto replay = read_replay(FLAGS_replay);
+    DEBUG("Read %d bytes from %s", replay.size(), FLAGS_replay.c_str());
+
+    auto map_content = read_map(&replay);
+    if (map_content.empty())
+        DEBUG("No map in replay");
+    else
+        DEBUG("Read map of %d bytes", map_content.size());
+
+    auto players = read_players(&replay);
+    DEBUG("Read %d players from replay", players->size());
+
+    auto spectators = read_players(&replay);
+    if (spectators->size() == 0)
+        DEBUG("No spectator in replay");
+    else
+        DEBUG("Read %d spectators from replay", spectators->size());
+
+    // Set the rules options
+    rules::Options rules_opt{};
+    rules_opt.map_content = map_content;
+    rules_opt.verbose = FLAGS_verbose;
+    rules_opt.players = players;
+    rules_opt.spectators = spectators;
+    rules_init(rules_opt);
+
+    // Process actions from replay
+    auto msgr = std::make_shared<rules::ReplayMessenger>(&replay);
+    replay_loop(msgr);
+
+    rules_result();
+
+    auto replay_result = read_result(&replay);
+
+    if (!replay.empty())
+        WARN("Replay contains %d extra bytes", replay.size());
+
+    // Compare saved and replayed results
+    if (!compare_results(*replay_result, *players))
+    {
+        WARN("Match results mismatch!");
+        WARN("Results saved in replay:");
+        std::cout << replay_result->scores_yaml();
+        WARN("Computed results:");
+    }
+
+    std::cout << players->scores_yaml();
+}
+
+utils::Buffer Replay::read_replay(const std::string& replay_path)
+{
+    auto stream = std::ifstream(replay_path, std::ios::binary);
+    std::vector<uint8_t> replay_data;
+    std::for_each(std::istreambuf_iterator<char>(stream),
+                  std::istreambuf_iterator<char>(),
+                  [&replay_data](const char c) { replay_data.push_back(c); });
+    return utils::Buffer{replay_data};
+}
+
+std::string Replay::read_map(utils::Buffer* replay)
+{
+    std::string map;
+    replay->handle(map);
+    return map;
+}
+
+rules::Players_sptr Replay::read_players(utils::Buffer* replay)
+{
+    auto players = std::make_shared<rules::Players>();
+    replay->handle_bufferizable(players.get());
+    return players;
+}
+
+rules::Players_sptr Replay::read_result(utils::Buffer* replay)
+{
+    // Final scores are extracted from the players save
+    return read_players(replay);
+}
+
+bool Replay::compare_results(const rules::Players& ref,
+                             const rules::Players& actual) const
+{
+    if (ref.size() != actual.size())
+        return false;
+    for (size_t i = 0; i < ref.size(); ++i)
+    {
+        const auto& player_ref = ref.players[i];
+        const auto& player_actual = actual.players[i];
+        if (player_ref->id != player_actual->id)
+            return false;
+        if (player_ref->name != player_actual->name)
+            return false;
+        if (player_ref->score != player_actual->score)
+            return false;
+    }
+    return true;
+}

--- a/src/replay/replay.hh
+++ b/src/replay/replay.hh
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2019 Association Prologin <association@prologin.org>
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <rules/types.hh>
+#include <utils/buffer.hh>
+#include <utils/dll.hh>
+
+class Replay
+{
+public:
+    bool check() const;
+    void run();
+
+private:
+    utils::Buffer read_replay(const std::string& replay_path);
+    std::string read_map(utils::Buffer* replay);
+    rules::Players_sptr read_players(utils::Buffer* replay);
+    rules::Players_sptr read_result(utils::Buffer* replay);
+
+    bool compare_results(const rules::Players& ref,
+                         const rules::Players& actual) const;
+};

--- a/src/server/server.hh
+++ b/src/server/server.hh
@@ -22,6 +22,8 @@ private:
     void sckt_init();
     void sckt_close();
     void wait_for_players();
+    std::shared_ptr<std::ostream> replay_init();
+    void replay_save_results(std::shared_ptr<std::ostream> replay_stream);
 
     rules::f_rules_init rules_init;
     rules::f_rules_result rules_result;

--- a/tools/generator/templates/rules/entry.cc.jinja2
+++ b/tools/generator/templates/rules/entry.cc.jinja2
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <memory>
 #include <rules/client-messenger.hh>
+#include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>
 
@@ -32,6 +33,11 @@ void rules_result()
 void player_loop(rules::ClientMessenger_sptr msgr)
 {
     rules_->player_loop(msgr);
+}
+
+void replay_loop(rules::ReplayMessenger_sptr msgr)
+{
+    rules_->replay_loop(msgr);
 }
 
 void server_loop(rules::ServerMessenger_sptr msgr)

--- a/tools/rubygenerator/files/entry.cc
+++ b/tools/rubygenerator/files/entry.cc
@@ -2,7 +2,9 @@
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
 #include <cstdlib>
 #include <memory>
+
 #include <rules/client-messenger.hh>
+#include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>
 
@@ -31,6 +33,11 @@ void rules_result()
 void player_loop(rules::ClientMessenger_sptr msgr)
 {
     rules_->player_loop(msgr);
+}
+
+void replay_loop(rules::ReplayMessenger_sptr msgr)
+{
+    rules_->replay_loop(msgr);
 }
 
 void server_loop(rules::ServerMessenger_sptr msgr)

--- a/tools/stechec2-run
+++ b/tools/stechec2-run
@@ -32,6 +32,7 @@ parser = argparse.ArgumentParser(
     spectators:
       - ./gui.so
     dump: dump.json
+    replay: replay.stechec2
 
 Report bugs to https://github.com/prologin/stechec2''',
     formatter_class=argparse.RawDescriptionHelpFormatter
@@ -118,8 +119,8 @@ def stechec2_run(args, options):
 
     # Check options
     options_whitelist = ['server', 'client', 'rules', 'map', 'verbose',
-                         'clients', 'names', 'spectators', 'dump', 'time',
-                         'memory']
+                         'clients', 'names', 'spectators', 'dump', 'replay',
+                         'time', 'memory']
     for opt in options:
         if opt not in options_whitelist:
             sys.exit("Error in yaml config file, unknown option: " + opt)
@@ -161,7 +162,7 @@ def stechec2_run(args, options):
                  "in your yaml configuration?")
 
     server_opt += ['--nb_clients', str(clients_count)]
-    for i in ['dump']:
+    for i in ['dump', 'replay']:
         if i in options:
             server_opt += ['--' + i, str(options[i])]
 

--- a/wscript
+++ b/wscript
@@ -239,6 +239,7 @@ def build_server(bld):
                 ],
                 use=['stechec2', 'gflags'])
 
+
 def build_replay(bld):
     bld.program(source='''
             src/replay/main.cc

--- a/wscript
+++ b/wscript
@@ -151,6 +151,7 @@ def build(bld):
 
     if not bld.env.GAMES_ONLY:
         build_client(bld)
+        build_replay(bld)
         build_server(bld)
 
         bld.recurse('tools')
@@ -181,6 +182,7 @@ def build_lib(bld):
 
             src/lib/rules/actions.cc
             src/lib/rules/client-messenger.cc
+            src/lib/rules/replay-messenger.cc
             src/lib/rules/server-messenger.cc
             src/lib/rules/rules.cc
             src/lib/rules/options.cc
@@ -233,6 +235,18 @@ def build_server(bld):
                 target='stechec2-server',
                 defines=[
                     'MODULE_COLOR=ANSI_COL_RED', 'MODULE_NAME="server"',
+                    'MODULE_VERSION="%s"' % VERSION
+                ],
+                use=['stechec2', 'gflags'])
+
+def build_replay(bld):
+    bld.program(source='''
+            src/replay/main.cc
+            src/replay/replay.cc
+        ''',
+                target='stechec2-replay',
+                defines=[
+                    'MODULE_COLOR=ANSI_COL_RED', 'MODULE_NAME="replay"',
                     'MODULE_VERSION="%s"' % VERSION
                 ],
                 use=['stechec2', 'gflags'])


### PR DESCRIPTION
From the proposed stechec2-replay documentation:

---

Debugging or testing the rules require starting a server and multiple clients.
This process is simplified by the ``stechec2-run`` utility, but it still
require you to have the champions compiled locally. This setup is not
straightforward and may not even reproduce a specific bug if the champions
generate random actions.

To create a standalone copy of a match, you can create a match replay file with
the ``--replay`` command line argument of ``stechec2-server``:

    stechec2-server --replay match.replay ...

The replay file can be read by the ``stechec2-replay`` utility, which only
requires the rules shared library to be present to replay a match:

    stechec2-replay --replay match.replay --rules rules.so

You can use this feature to replay a match that triggers a specific bug, or use
the replay file a unit test.

---

Next steps:

* Add support for fetching replays in concours/
* Add a text-based action representation for text-based replays
* Add test infrastructure to use replays as test cases.