### PR TITLE
Refactor Players_sptr

### DIFF
--- a/games/plusminus/src/api.cc
+++ b/games/plusminus/src/api.cc
@@ -9,7 +9,8 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+Api::Api(std::unique_ptr<GameState> game_state,
+         std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {
     api = this;

--- a/games/plusminus/src/api.hh
+++ b/games/plusminus/src/api.hh
@@ -20,7 +20,8 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
+    Api(std::unique_ptr<GameState> game_state,
+        std::shared_ptr<rules::Player> player);
     ~Api() {}
 
     /// Provide your guess

--- a/games/plusminus/src/game_state.cc
+++ b/games/plusminus/src/game_state.cc
@@ -11,7 +11,7 @@ GameState::GameState(const std::string& map_content,
 {
     std::istringstream map_stream{map_content};
     map_stream >> secret_number;
-    for (const auto& p : players_.all())
+    for (const auto& p : players_)
         player_guess_map[p->id] = -2; // default value
 }
 

--- a/games/plusminus/src/game_state.cc
+++ b/games/plusminus/src/game_state.cc
@@ -6,12 +6,12 @@
 #include <sstream>
 
 GameState::GameState(const std::string& map_content,
-                     rules::Players_sptr players)
-    : secret_number_found(false), round(0), players_(players)
+                     const rules::Players& players)
+    : rules::GameState(players), secret_number_found(false), round(0)
 {
     std::istringstream map_stream{map_content};
     map_stream >> secret_number;
-    for (const auto& p : players_->players)
+    for (const auto& p : players_.all())
         player_guess_map[p->id] = -2; // default value
 }
 

--- a/games/plusminus/src/game_state.hh
+++ b/games/plusminus/src/game_state.hh
@@ -10,7 +10,7 @@
 class GameState final : public rules::GameState
 {
 public:
-    GameState(const std::string& map_content, rules::Players_sptr players);
+    GameState(const std::string& map_content, const rules::Players& players);
     GameState(const GameState& st) = default;
     ~GameState() = default;
 
@@ -22,7 +22,4 @@ public:
     bool secret_number_found;
     int round;
     std::unordered_map<uint32_t, int> player_guess_map;
-
-private:
-    rules::Players_sptr players_;
 };

--- a/games/plusminus/src/rules.cc
+++ b/games/plusminus/src/rules.cc
@@ -100,7 +100,7 @@ void Rules::end_of_round()
 
 void Rules::at_end()
 {
-    for (const auto& p : players_.all())
+    for (const auto& p : players_)
     {
         auto guess = api_->game_state().player_guess_map[p->id];
         if (guess == 0)

--- a/games/plusminus/src/rules.cc
+++ b/games/plusminus/src/rules.cc
@@ -100,7 +100,7 @@ void Rules::end_of_round()
 
 void Rules::at_end()
 {
-    for (auto& p : players_->players)
+    for (const auto& p : players_.all())
     {
         auto guess = api_->game_state().player_guess_map[p->id];
         if (guess == 0)

--- a/games/tictactoe/src/api.cc
+++ b/games/tictactoe/src/api.cc
@@ -10,7 +10,8 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+Api::Api(std::unique_ptr<GameState> game_state,
+         std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {
     api = this;

--- a/games/tictactoe/src/api.hh
+++ b/games/tictactoe/src/api.hh
@@ -18,7 +18,8 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
+    Api(std::unique_ptr<GameState> game_state,
+        std::shared_ptr<rules::Player> player);
 
     /// Play at the given position
     ApiActionFunc<ActionPlay> play{this};

--- a/games/tictactoe/src/game_state.cc
+++ b/games/tictactoe/src/game_state.cc
@@ -4,12 +4,12 @@
 
 #include <algorithm>
 
-GameState::GameState(rules::Players_sptr players)
-    : players_(players)
+GameState::GameState(const rules::Players& players)
+    : rules::GameState(players)
     , board_({NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER,
               NO_PLAYER, NO_PLAYER, NO_PLAYER})
 {
-    for (auto& player : players->players)
+    for (const auto& player : players_.all())
         if (player->type == rules::PLAYER)
             is_player_turn_.emplace(std::make_pair(player->id, false));
 }
@@ -92,7 +92,7 @@ void GameState::compute_scores()
     auto winner_id = winner();
     if (winner_id == NO_PLAYER)
         return;
-    for (auto player : players_->players)
+    for (const auto& player : players_.all())
     {
         if (player->id == (uint32_t)winner_id)
         {

--- a/games/tictactoe/src/game_state.cc
+++ b/games/tictactoe/src/game_state.cc
@@ -9,7 +9,7 @@ GameState::GameState(const rules::Players& players)
     , board_({NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER,
               NO_PLAYER, NO_PLAYER, NO_PLAYER})
 {
-    for (const auto& player : players_.all())
+    for (const auto& player : players_)
         if (player->type == rules::PLAYER)
             is_player_turn_.emplace(std::make_pair(player->id, false));
 }
@@ -92,7 +92,7 @@ void GameState::compute_scores()
     auto winner_id = winner();
     if (winner_id == NO_PLAYER)
         return;
-    for (const auto& player : players_.all())
+    for (const auto& player : players_)
     {
         if (player->id == (uint32_t)winner_id)
         {

--- a/games/tictactoe/src/game_state.hh
+++ b/games/tictactoe/src/game_state.hh
@@ -15,7 +15,7 @@ class GameState : public rules::GameState
 public:
     const int NO_PLAYER = -1;
 
-    GameState(rules::Players_sptr players);
+    GameState(const rules::Players& players);
     GameState* copy() const override;
 
     std::vector<int> get_board() const;
@@ -32,8 +32,6 @@ public:
     bool is_player_turn(int player_id) const;
 
 private:
-    rules::Players_sptr players_;
-
     std::unordered_map<int, bool> is_player_turn_;
     std::vector<int> board_;
 };

--- a/games/tictactoe/src/tests/test-helpers.hh
+++ b/games/tictactoe/src/tests/test-helpers.hh
@@ -10,14 +10,13 @@
 #include "../game_state.hh"
 #include "../rules.hh"
 
-static rules::Players_sptr make_players(int id1, int id2)
+static rules::Players make_players(int id1, int id2)
 {
     // Create two players (no spectator)
-    return rules::Players_sptr(
-        new rules::Players{std::vector<rules::Player_sptr>{
-            rules::Player_sptr(new rules::Player(id1, rules::PLAYER)),
-            rules::Player_sptr(new rules::Player(id2, rules::PLAYER)),
-        }});
+    rules::Players players;
+    players.add(std::make_shared<rules::Player>(id1, rules::PLAYER));
+    players.add(std::make_shared<rules::Player>(id2, rules::PLAYER));
+    return players;
 }
 
 class ActionTest : public ::testing::Test
@@ -41,13 +40,13 @@ protected:
     virtual void SetUp()
     {
         utils::Logger::get().level() = utils::Logger::DEBUG_LEVEL;
-        auto players_ptr = make_players(PLAYER_1, PLAYER_2);
+        auto rules_players = make_players(PLAYER_1, PLAYER_2);
         players[0].id = PLAYER_1;
         players[0].api = std::make_unique<Api>(
-            std::make_unique<GameState>(players_ptr), players_ptr->players[0]);
+            std::make_unique<GameState>(rules_players), rules_players.all()[0]);
         players[1].id = PLAYER_2;
         players[1].api = std::make_unique<Api>(
-            std::make_unique<GameState>(players_ptr), players_ptr->players[1]);
+            std::make_unique<GameState>(rules_players), rules_players.all()[1]);
     }
 
     struct Player

--- a/games/tictactoe/src/tests/test-helpers.hh
+++ b/games/tictactoe/src/tests/test-helpers.hh
@@ -43,10 +43,10 @@ protected:
         auto rules_players = make_players(PLAYER_1, PLAYER_2);
         players[0].id = PLAYER_1;
         players[0].api = std::make_unique<Api>(
-            std::make_unique<GameState>(rules_players), rules_players.all()[0]);
+            std::make_unique<GameState>(rules_players), rules_players[0]);
         players[1].id = PLAYER_2;
         players[1].api = std::make_unique<Api>(
-            std::make_unique<GameState>(rules_players), rules_players.all()[1]);
+            std::make_unique<GameState>(rules_players), rules_players[1]);
     }
 
     struct Player

--- a/src/client/client.cc
+++ b/src/client/client.cc
@@ -36,9 +36,6 @@ Client::Client()
         client_loop = rules_lib_->get<rules::f_client_loop>("spectator_loop");
     else
         client_loop = rules_lib_->get<rules::f_client_loop>("player_loop");
-
-    players_ = rules::Players_sptr(new rules::Players());
-    spectators_ = rules::Players_sptr(new rules::Players());
 }
 
 void Client::run()
@@ -113,7 +110,7 @@ void Client::sckt_init()
         (msg.handle_buffer(*buf_rep), msg.client_id == 0))
         FATAL("Unable to get an ID from the server");
 
-    player_ = rules::Player_sptr(new rules::Player(msg.client_id, client_type));
+    player_ = std::make_shared<rules::Player>(msg.client_id, client_type);
     player_->name = FLAGS_name;
 
     NOTICE("Connected - id: %i", player_->id);
@@ -136,7 +133,7 @@ void Client::wait_for_players()
         msg.handle_buffer(*buf);
 
         if ((msg_type = msg.type) == net::MSG_PLAYERS)
-            players_->handle_buffer(*buf);
+            players_.handle_buffer(*buf);
     }
 
     // Wait for spectators
@@ -147,7 +144,7 @@ void Client::wait_for_players()
         msg.handle_buffer(*buf);
 
         if ((msg_type = msg.type) == net::MSG_PLAYERS)
-            spectators_->handle_buffer(*buf);
+            spectators_.handle_buffer(*buf);
     }
 }
 

--- a/src/client/client.hh
+++ b/src/client/client.hh
@@ -31,9 +31,9 @@ private:
 private:
     std::unique_ptr<utils::DLL> rules_lib_;
 
-    rules::Player_sptr player_;
-    rules::Players_sptr players_;
-    rules::Players_sptr spectators_;
+    std::shared_ptr<rules::Player> player_;
+    rules::Players players_;
+    rules::Players spectators_;
     rules::ClientMessenger_sptr msgr_;
 
     std::unique_ptr<net::ClientSocket> sckt_;

--- a/src/lib/rules/api.hh
+++ b/src/lib/rules/api.hh
@@ -62,12 +62,12 @@ protected:
     };
 
 public:
-    Api(std::unique_ptr<GameState> game_state, Player_sptr player)
+    Api(std::unique_ptr<GameState> game_state, std::shared_ptr<Player> player)
         : game_state_(std::move(game_state)), player_(player)
     {}
     virtual ~Api() {}
 
-    const Player_sptr player() const { return player_; }
+    const std::shared_ptr<Player> player() const { return player_; }
 
     Actions* actions() { return &actions_; }
 
@@ -98,7 +98,7 @@ public:
 
 protected:
     GameStateHistory<GameState> game_state_;
-    Player_sptr player_;
+    std::shared_ptr<Player> player_;
     Actions actions_;
 };
 

--- a/src/lib/rules/game-state.hh
+++ b/src/lib/rules/game-state.hh
@@ -3,16 +3,19 @@
 #pragma once
 
 #include "action.hh"
+#include "player.hh"
 
 namespace rules {
 
 class GameState
 {
 public:
-    GameState() = default;
+    GameState() : players_{} {}
+    GameState(const Players players) : players_{players} {}
     virtual ~GameState() = default;
 
     // Explicit copy of the game state
+    // TODO(halfr): add default implem and return a std::unique_ptr
     virtual GameState* copy() const = 0;
 
     int check(const IAction& action) const { return action.check(*this); }
@@ -21,6 +24,8 @@ public:
 protected:
     // Protected to be called by copy()
     GameState(const GameState&) = default;
+
+    const Players players_;
 };
 
 } // namespace rules

--- a/src/lib/rules/options.hh
+++ b/src/lib/rules/options.hh
@@ -29,13 +29,13 @@ struct Options
     uint32_t time;
 
     // Player
-    Player_sptr player;
+    std::shared_ptr<Player> player;
 
     // Players
-    Players_sptr players;
+    Players players;
 
     // Spectators
-    Players_sptr spectators;
+    Players spectators;
 
     // Verbosity of the logs displayed/written
     unsigned verbose;

--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -48,11 +48,14 @@ public:
     {
         if (buf.serialize())
         {
-            for (const auto& p : players_)
-                p->handle_buffer(buf);
+            for (const auto& player : players_)
+                player->handle_buffer(buf);
         }
         else
         {
+            // Reset
+            players_.clear();
+
             while (!buf.empty())
             {
                 // Get a player
@@ -90,7 +93,8 @@ public:
 
     size_t size() const { return players_.size(); }
 
-    const PlayersVector& all() const { return players_; }
+    auto begin() const { return players_.begin(); }
+    auto end() const { return players_.end(); }
 
 private:
     PlayersVector players_;

--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -96,6 +96,12 @@ public:
     auto begin() const { return players_.begin(); }
     auto end() const { return players_.end(); }
 
+    auto front() const { return players_.front(); }
+    auto back() const { return players_.back(); }
+
+    auto operator[](int i) { return players_[i]; }
+    auto operator[](int i) const { return players_[i]; }
+
 private:
     PlayersVector players_;
 };

--- a/src/lib/rules/rules.cc
+++ b/src/lib/rules/rules.cc
@@ -26,7 +26,7 @@ void Rules::save_player_actions(Actions* actions)
 
 bool Rules::is_spectator(uint32_t id)
 {
-    for (const auto& spectator : spectators_.all())
+    for (const auto& spectator : spectators_)
         if (spectator->id == id)
             return true;
 
@@ -127,13 +127,13 @@ void SynchronousRules::spectator_loop(ClientMessenger_sptr msgr)
 void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
 {
     std::unordered_set<uint32_t> spectators_ids;
-    for (const auto& spectator : spectators_.all())
+    for (const auto& spectator : spectators_)
         spectators_ids.insert(spectator->id);
 
     std::unordered_set<uint32_t> players_ids;
-    for (const auto& player : players_.all())
+    for (const auto& player : players_)
         players_ids.insert(player->id);
-    for (const auto& spectator : spectators_.all())
+    for (const auto& spectator : spectators_)
         players_ids.insert(spectator->id);
 
     std::set<uint32_t> players_timeouting;
@@ -153,7 +153,7 @@ void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
         actions->clear();
 
         players_timeouting.clear();
-        for (const auto& player : players_.all())
+        for (const auto& player : players_)
             players_timeouting.insert(player->id);
 
         for (size_t i = 0; i < players_count; ++i)
@@ -177,7 +177,7 @@ void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
         }
 
         // Increase timeout count for players that did not answer in time
-        for (const auto& player : players_.all())
+        for (const auto& player : players_)
         {
             if (players_timeouting.find(player->id) != players_timeouting.end())
             {
@@ -307,7 +307,7 @@ void TurnBasedRules::replay_loop(ReplayMessenger_sptr msgr)
     while (!is_finished())
     {
         start_of_round();
-        for (const auto& player : players_.all())
+        for (const auto& player : players_)
         {
             DEBUG("Turn for player: %d", player->id);
 
@@ -323,7 +323,7 @@ void TurnBasedRules::replay_loop(ReplayMessenger_sptr msgr)
             end_of_player_turn(player->id);
             end_of_turn(player->id);
 
-            for (const auto& spectator : spectators_.all())
+            for (const auto& spectator : spectators_)
             {
                 DEBUG("Turn for spectator %d", spectator->id);
 
@@ -448,7 +448,7 @@ void TurnBasedRules::spectator_loop(ClientMessenger_sptr msgr)
 
 void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 {
-    msgr->push_id(players_.all().back()->id);
+    msgr->push_id(players_.back()->id);
 
     at_start();
     at_server_start(msgr);
@@ -459,7 +459,7 @@ void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 
     while (!is_finished())
     {
-        for (const auto& player : players_.all())
+        for (const auto& player : players_)
         {
             start_of_player_turn(player->id);
             start_of_turn(player->id);
@@ -500,7 +500,7 @@ void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 
             /* Spectators must be able to see the state of the game between
              * after each player has finished its turn. */
-            for (const auto& s : spectators_.all())
+            for (const auto& s : spectators_)
             {
                 start_of_spectator_turn(s->id);
                 start_of_turn(s->id);

--- a/src/lib/rules/rules.cc
+++ b/src/lib/rules/rules.cc
@@ -26,9 +26,11 @@ void Rules::save_player_actions(Actions* actions)
 
 bool Rules::is_spectator(uint32_t id)
 {
-    return std::any_of(
-        spectators_->players.cbegin(), spectators_->players.cend(),
-        [id](const Player_sptr& spectator) { return spectator->id == id; });
+    for (const auto& spectator : spectators_.all())
+        if (spectator->id == id)
+            return true;
+
+    return false;
 }
 
 /*-----------------.
@@ -125,18 +127,17 @@ void SynchronousRules::spectator_loop(ClientMessenger_sptr msgr)
 void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
 {
     std::unordered_set<uint32_t> spectators_ids;
-    for (const auto& spectator : spectators_->players)
+    for (const auto& spectator : spectators_.all())
         spectators_ids.insert(spectator->id);
 
     std::unordered_set<uint32_t> players_ids;
-    for (const auto& player : players_->players)
+    for (const auto& player : players_.all())
         players_ids.insert(player->id);
-    for (const auto& spectator : spectators_->players)
+    for (const auto& spectator : spectators_.all())
         players_ids.insert(spectator->id);
 
     std::set<uint32_t> players_timeouting;
-    size_t players_count =
-        players_->players.size() + spectators_->players.size();
+    unsigned int players_count = players_.size() + spectators_.size();
 
     at_start();
     at_server_start(msgr);
@@ -145,14 +146,14 @@ void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
 
     while (!is_finished())
     {
-        size_t spectators_count = spectators_->players.size();
+        auto spectators_count = spectators_.size();
         start_of_round();
 
         auto actions = get_actions();
         actions->clear();
 
         players_timeouting.clear();
-        for (const auto& player : players_->players)
+        for (const auto& player : players_.all())
             players_timeouting.insert(player->id);
 
         for (size_t i = 0; i < players_count; ++i)
@@ -176,24 +177,16 @@ void SynchronousRules::server_loop(ServerMessenger_sptr msgr)
         }
 
         // Increase timeout count for players that did not answer in time
-        for (const auto player_id : players_timeouting)
+        for (const auto& player : players_.all())
         {
-            uint32_t player_id_timeouting = 0;
-            for (uint32_t i = 0; i < players_->players.size(); ++i)
+            if (players_timeouting.find(player->id) != players_timeouting.end())
             {
-                if (player_id == players_->players[i]->id)
+                player->nb_timeout += 1;
+                if (player->nb_timeout == 3)
                 {
-                    player_id_timeouting = i;
-                    break;
+                    players_ids.erase(player->id);
+                    players_count--;
                 }
-            }
-
-            players_->players[player_id_timeouting]->nb_timeout++;
-
-            if (players_->players[player_id_timeouting]->nb_timeout == 3)
-            {
-                players_ids.erase(player_id);
-                players_count--;
             }
         }
 
@@ -314,7 +307,7 @@ void TurnBasedRules::replay_loop(ReplayMessenger_sptr msgr)
     while (!is_finished())
     {
         start_of_round();
-        for (const auto& player : players_->players)
+        for (const auto& player : players_.all())
         {
             DEBUG("Turn for player: %d", player->id);
 
@@ -330,7 +323,7 @@ void TurnBasedRules::replay_loop(ReplayMessenger_sptr msgr)
             end_of_player_turn(player->id);
             end_of_turn(player->id);
 
-            for (const auto& spectator : spectators_->players)
+            for (const auto& spectator : spectators_.all())
             {
                 DEBUG("Turn for spectator %d", spectator->id);
 
@@ -455,7 +448,7 @@ void TurnBasedRules::spectator_loop(ClientMessenger_sptr msgr)
 
 void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 {
-    msgr->push_id(players_->players[players_->players.size() - 1]->id);
+    msgr->push_id(players_.all().back()->id);
 
     at_start();
     at_server_start(msgr);
@@ -466,7 +459,7 @@ void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 
     while (!is_finished())
     {
-        for (const auto& player : players_->players)
+        for (const auto& player : players_.all())
         {
             start_of_player_turn(player->id);
             start_of_turn(player->id);
@@ -507,7 +500,7 @@ void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 
             /* Spectators must be able to see the state of the game between
              * after each player has finished its turn. */
-            for (auto& s : spectators_->players)
+            for (const auto& s : spectators_.all())
             {
                 start_of_spectator_turn(s->id);
                 start_of_turn(s->id);

--- a/src/lib/rules/rules.hh
+++ b/src/lib/rules/rules.hh
@@ -85,8 +85,8 @@ protected:
 
     Options opt_;
 
-    Players_sptr players_;
-    Players_sptr spectators_;
+    Players players_;
+    Players spectators_;
 
     int timeout_;
 };

--- a/src/replay/replay.cc
+++ b/src/replay/replay.cc
@@ -46,13 +46,13 @@ void Replay::run()
         DEBUG("Read map of %d bytes", map_content.size());
 
     auto players = read_players(&replay);
-    DEBUG("Read %d players from replay", players->size());
+    DEBUG("Read %d players from replay", players.size());
 
     auto spectators = read_players(&replay);
-    if (spectators->size() == 0)
+    if (spectators.size() == 0)
         DEBUG("No spectator in replay");
     else
-        DEBUG("Read %d spectators from replay", spectators->size());
+        DEBUG("Read %d spectators from replay", spectators.size());
 
     // Set the rules options
     rules::Options rules_opt{};
@@ -74,15 +74,15 @@ void Replay::run()
         WARN("Replay contains %d extra bytes", replay.size());
 
     // Compare saved and replayed results
-    if (!compare_results(*replay_result, *players))
+    if (!compare_results(replay_result, players))
     {
         WARN("Match results mismatch!");
         WARN("Results saved in replay:");
-        std::cout << replay_result->scores_yaml();
+        std::cout << replay_result.scores_yaml();
         WARN("Computed results:");
     }
 
-    std::cout << players->scores_yaml();
+    std::cout << players.scores_yaml();
 }
 
 utils::Buffer Replay::read_replay(const std::string& replay_path)
@@ -102,14 +102,14 @@ std::string Replay::read_map(utils::Buffer* replay)
     return map;
 }
 
-rules::Players_sptr Replay::read_players(utils::Buffer* replay)
+rules::Players Replay::read_players(utils::Buffer* replay)
 {
-    auto players = std::make_shared<rules::Players>();
-    replay->handle_bufferizable(players.get());
+    rules::Players players;
+    replay->handle_bufferizable(&players);
     return players;
 }
 
-rules::Players_sptr Replay::read_result(utils::Buffer* replay)
+rules::Players Replay::read_result(utils::Buffer* replay)
 {
     // Final scores are extracted from the players save
     return read_players(replay);
@@ -122,8 +122,8 @@ bool Replay::compare_results(const rules::Players& ref,
         return false;
     for (size_t i = 0; i < ref.size(); ++i)
     {
-        const auto& player_ref = ref.players[i];
-        const auto& player_actual = actual.players[i];
+        const auto& player_ref = ref.all()[i];
+        const auto& player_actual = actual.all()[i];
         if (player_ref->id != player_actual->id)
             return false;
         if (player_ref->name != player_actual->name)

--- a/src/replay/replay.cc
+++ b/src/replay/replay.cc
@@ -122,8 +122,8 @@ bool Replay::compare_results(const rules::Players& ref,
         return false;
     for (size_t i = 0; i < ref.size(); ++i)
     {
-        const auto& player_ref = ref.all()[i];
-        const auto& player_actual = actual.all()[i];
+        const auto& player_ref = ref[i];
+        const auto& player_actual = actual[i];
         if (player_ref->id != player_actual->id)
             return false;
         if (player_ref->name != player_actual->name)

--- a/src/replay/replay.hh
+++ b/src/replay/replay.hh
@@ -18,8 +18,8 @@ public:
 private:
     utils::Buffer read_replay(const std::string& replay_path);
     std::string read_map(utils::Buffer* replay);
-    rules::Players_sptr read_players(utils::Buffer* replay);
-    rules::Players_sptr read_result(utils::Buffer* replay);
+    rules::Players read_players(utils::Buffer* replay);
+    rules::Players read_result(utils::Buffer* replay);
 
     bool compare_results(const rules::Players& ref,
                          const rules::Players& actual) const;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -113,8 +113,8 @@ void Server::sckt_close()
 
 bool used_identifier(uint32_t player_id, const rules::Players& players)
 {
-    for (const auto& p : players.all())
-        if (p->id == player_id)
+    for (const auto& player : players)
+        if (player->id == player_id)
             return true;
     return false;
 }

--- a/src/server/server.hh
+++ b/src/server/server.hh
@@ -33,8 +33,8 @@ private:
     uint32_t nb_players_;
     std::unique_ptr<utils::DLL> rules_lib_;
 
-    rules::Players_sptr players_;
-    rules::Players_sptr spectators_;
+    rules::Players players_;
+    rules::Players spectators_;
     rules::ServerMessenger_sptr msgr_;
 
     std::unique_ptr<net::ServerSocket> sckt_;

--- a/tools/generator/templates/rules/src/api.cc.jinja2
+++ b/tools/generator/templates/rules/src/api.cc.jinja2
@@ -9,7 +9,8 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player)
+Api::Api(std::unique_ptr<GameState> game_state,
+         std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {
     api = this;

--- a/tools/generator/templates/rules/src/api.hh.jinja2
+++ b/tools/generator/templates/rules/src/api.hh.jinja2
@@ -21,7 +21,8 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state, rules::Player_sptr player);
+    Api(std::unique_ptr<GameState> game_state,
+        std::shared_ptr<rules::Player> player);
     ~Api() {}
 
 {# Generate the C++ declaration for each API function #}

--- a/tools/generator/templates/rules/src/game_state.cc.jinja2
+++ b/tools/generator/templates/rules/src/game_state.cc.jinja2
@@ -3,14 +3,14 @@
 
 #include "game_state.hh"
 
-GameState::GameState(rules::Players_sptr players)
-    : rules::GameState(), players_(players)
+GameState::GameState(const rules::Players& players)
+    : rules::GameState(players)
 {
     // FIXME
 }
 
 GameState::GameState(const GameState& st)
-    : rules::GameState(st), players_(st.players_)
+    : rules::GameState(st)
 {
     // FIXME
 }

--- a/tools/generator/templates/rules/src/game_state.hh.jinja2
+++ b/tools/generator/templates/rules/src/game_state.hh.jinja2
@@ -11,12 +11,9 @@ class GameState final : public rules::GameState
 public:
     // FIXME
     // additional parameters? for instance map
-    GameState(rules::Players_sptr players);
+    GameState(const rules::Players& players);
     GameState(const GameState& st);
     ~GameState();
 
     GameState* copy() const override;
-
-private:
-    rules::Players_sptr players_;
 };


### PR DESCRIPTION
Players_sptr was std::shared_ptr<std::vector<std::shared_ptr<Player>>>.
There was no reason to have a shared_ptr holding other shared_ptrs.

This commit removes the Players_sptr type.

Also, this commit replaces the Player_sptr typedef with the underlying
type: std::shared_ptr<Player>. Rationale: let's be explicit about the
types.

Also, move the Players field of the game's GameState to the base class
rules::GameState.