### PR TITLE
rules: client id refactor

### DIFF
--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -39,6 +39,7 @@ First, we must write some config boilerplate at the top of the file::
 
   name: connect4  # The name of the game
   rules_type: turnbased # The type of rules to follow
+  player_count: 2 # The number of players
 
   constant:
     # Place your constants here

--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -38,8 +38,8 @@ Write the YAML
 First, we must write some config boilerplate at the top of the file::
 
   name: connect4  # The name of the game
-  rules_type: turnbased # The type of rules to follow
-  player_count: 2 # The number of players
+  rules_type: turnbased  # The type of rules to follow
+  player_count: 2  # The number of players
 
   constant:
     # Place your constants here

--- a/games/plusminus/plusminus.yml
+++ b/games/plusminus/plusminus.yml
@@ -1,5 +1,6 @@
 name: plusminus
 rules_type: synchronous
+player_count: 2
 
 enum:
   -

--- a/games/plusminus/src/entry.cc
+++ b/games/plusminus/src/entry.cc
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <rules/client-messenger.hh>
+#include <rules/config.hh>
 #include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>
@@ -18,6 +19,12 @@ struct Options;
 static Rules* rules_;
 
 extern "C" {
+
+void rules_config(rules::Config* cfg)
+{
+    cfg->name = "plusminus";
+    cfg->player_count = 2;
+}
 
 void rules_init(const rules::Options& opt)
 {

--- a/games/tictactoe/src/action_play.cc
+++ b/games/tictactoe/src/action_play.cc
@@ -8,7 +8,7 @@ int ActionPlay::check(const GameState& st) const
         return OUT_OF_BOUNDS;
     if (st.get_cell(pos_) != st.NO_PLAYER)
         return ALREADY_OCCUPIED;
-    if (!st.is_player_turn(player_id_))
+    if (!st.player_can_play(player_id_))
         return ALREADY_PLAYED;
 
     return OK;
@@ -17,5 +17,5 @@ int ActionPlay::check(const GameState& st) const
 void ActionPlay::apply_on(GameState* st) const
 {
     st->set_cell(pos_, player_id_);
-    st->set_player_turn(player_id_, false);
+    st->set_player_can_play(player_id_, false);
 }

--- a/games/tictactoe/src/entry.cc
+++ b/games/tictactoe/src/entry.cc
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <rules/client-messenger.hh>
+#include <rules/config.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>
 
@@ -17,6 +18,12 @@ struct Options;
 static Rules* rules_;
 
 extern "C" {
+
+void rules_config(rules::Config* cfg)
+{
+    cfg->name = "tictactoe";
+    cfg->player_count = 2;
+}
 
 void rules_init(const rules::Options& opt)
 {

--- a/games/tictactoe/src/game_state.cc
+++ b/games/tictactoe/src/game_state.cc
@@ -8,11 +8,7 @@ GameState::GameState(const rules::Players& players)
     : rules::GameState(players)
     , board_({NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER, NO_PLAYER,
               NO_PLAYER, NO_PLAYER, NO_PLAYER})
-{
-    for (const auto& player : players_)
-        if (player->type == rules::PLAYER)
-            is_player_turn_.emplace(std::make_pair(player->id, false));
-}
+{}
 
 GameState* GameState::copy() const
 {
@@ -84,7 +80,8 @@ bool GameState::is_board_full() const
 
 bool GameState::is_finished() const
 {
-    return is_board_full() || winner() != NO_PLAYER;
+    return current_player_ == LAST_PLAYER &&
+           (is_board_full() || winner() != NO_PLAYER);
 }
 
 void GameState::compute_scores()
@@ -96,22 +93,29 @@ void GameState::compute_scores()
     {
         if (player->id == (uint32_t)winner_id)
         {
-            player->score += 1;
+            player->score = 1;
             break;
         }
     }
 }
 
-void GameState::set_player_turn(int player_id, bool state)
+void GameState::set_current_player(int player_id)
 {
-    assert(is_player_turn_.count(player_id) != 0);
-    is_player_turn_.at(player_id) = state;
+    current_player_ = player_id;
 }
 
-bool GameState::is_player_turn(int player_id) const
+int GameState::get_current_player() const
 {
-    assert(is_player_turn_.count(player_id) != 0);
-    return is_player_turn_.at(player_id);
+    return current_player_;
+}
+
+void GameState::set_player_can_play(int player_id, bool can_play)
+{
+    player_can_play_.at(player_id) = can_play;
+}
+bool GameState::player_can_play(int player_id) const
+{
+    return player_can_play_.at(player_id);
 }
 
 std::ostream& operator<<(std::ostream& out, const GameState& gs)

--- a/games/tictactoe/src/game_state.hh
+++ b/games/tictactoe/src/game_state.hh
@@ -13,7 +13,7 @@
 class GameState : public rules::GameState
 {
 public:
-    const int NO_PLAYER = -1;
+    static constexpr int NO_PLAYER = -1;
 
     GameState(const rules::Players& players);
     GameState* copy() const override;
@@ -28,11 +28,18 @@ public:
     bool is_finished() const;
     void compute_scores();
 
-    void set_player_turn(int player_id, bool state);
-    bool is_player_turn(int player_id) const;
+    void set_current_player(int player_id);
+    int get_current_player() const;
+
+    void set_player_can_play(int player_id, bool can_play);
+    bool player_can_play(int player_id) const;
 
 private:
-    std::unordered_map<int, bool> is_player_turn_;
+    static constexpr size_t PLAYER_COUNT = 2;
+    static constexpr int LAST_PLAYER = PLAYER_COUNT - 1;
+
+    int current_player_;
+    std::array<bool, PLAYER_COUNT> player_can_play_;
     std::vector<int> board_;
 };
 

--- a/games/tictactoe/src/game_state.hh
+++ b/games/tictactoe/src/game_state.hh
@@ -13,7 +13,7 @@
 class GameState : public rules::GameState
 {
 public:
-    static constexpr int NO_PLAYER = -1;
+    const int NO_PLAYER = -1;
 
     GameState(const rules::Players& players);
     GameState* copy() const override;

--- a/games/tictactoe/src/rules.cc
+++ b/games/tictactoe/src/rules.cc
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright (c) 2012 Association Prologin <association@prologin.org>
-#include "actions.hh"
 #include "rules.hh"
+#include "actions.hh"
 
 Rules::Rules(const rules::Options opt) : TurnBasedRules(opt), sandbox_(opt.time)
 {
@@ -101,15 +101,17 @@ void Rules::spectator_turn()
 
 void Rules::start_of_player_turn(unsigned int player_id)
 {
-    api_->game_state().set_player_turn(player_id, true);
+    api_->game_state().set_current_player(player_id);
+    api_->game_state().set_player_can_play(player_id, true);
 }
 
-void Rules::end_of_player_turn(unsigned int /* player_id */)
+void Rules::end_of_player_turn(unsigned int player_id)
 {
     // Clear the list of game states at the end of each turn (half-round)
     // We need the linked list of game states only for undo and history,
     // therefore old states are not needed anymore after the turn ends.
     api_->clear_old_game_states();
+    api_->game_state().set_player_can_play(player_id, false);
     api_->game_state().compute_scores();
 }
 

--- a/games/tictactoe/src/tests/test-action_play.cc
+++ b/games/tictactoe/src/tests/test-action_play.cc
@@ -7,7 +7,7 @@
 
 TEST_F(ActionTest, ActionPlay_OutOfBounds)
 {
-    st->set_player_turn(PLAYER_1, true);
+    st->set_player_can_play(PLAYER_1, true);
 
     for (position pos : {(position){-1, 1}, {3, 1}, {0, 4}, {2, -7}})
     {
@@ -18,8 +18,8 @@ TEST_F(ActionTest, ActionPlay_OutOfBounds)
 
 TEST_F(ActionTest, ActionPlay_AlreadyOccupied)
 {
-    st->set_player_turn(PLAYER_1, true);
-    st->set_player_turn(PLAYER_2, true);
+    st->set_player_can_play(PLAYER_1, true);
+    st->set_player_can_play(PLAYER_2, true);
 
     position pos = {1, 1};
     ActionPlay act(pos, PLAYER_1);
@@ -39,7 +39,7 @@ TEST_F(ActionTest, ActionPlay_AlreadyOccupied)
 
 TEST_F(ActionTest, ActionPlay_AlreadyPlayed)
 {
-    st->set_player_turn(PLAYER_1, true);
+    st->set_player_can_play(PLAYER_1, true);
 
     ActionPlay act({0, 0}, PLAYER_1);
     EXPECT_EQ(OK, act.check(*st));
@@ -51,8 +51,8 @@ TEST_F(ActionTest, ActionPlay_AlreadyPlayed)
 
 TEST_F(ActionTest, ActionPlay_Ok)
 {
-    st->set_player_turn(PLAYER_1, true);
-    st->set_player_turn(PLAYER_2, true);
+    st->set_player_can_play(PLAYER_1, true);
+    st->set_player_can_play(PLAYER_2, true);
 
     ActionPlay act({0, 0}, PLAYER_1);
     EXPECT_EQ(OK, act.check(*st));

--- a/games/tictactoe/src/tests/test-api.cc
+++ b/games/tictactoe/src/tests/test-api.cc
@@ -15,7 +15,7 @@ TEST_F(ApiTest, Api_Board)
     for (auto& player : players)
     {
         std::vector<int> board = player.api->board();
-        std::vector<int> expected(9, GameState::NO_PLAYER);
+        std::vector<int> expected(9, player.api->game_state().NO_PLAYER);
         EXPECT_EQ(board, expected);
 
         player.api->game_state().set_player_can_play(player.id, true);

--- a/games/tictactoe/src/tests/test-api.cc
+++ b/games/tictactoe/src/tests/test-api.cc
@@ -15,7 +15,7 @@ TEST_F(ApiTest, Api_Board)
     for (auto& player : players)
     {
         std::vector<int> board = player.api->board();
-        std::vector<int> expected(9, player.api->game_state().NO_PLAYER);
+        std::vector<int> expected(9, GameState::NO_PLAYER);
         EXPECT_EQ(board, expected);
 
         player.api->game_state().set_player_can_play(player.id, true);

--- a/games/tictactoe/src/tests/test-api.cc
+++ b/games/tictactoe/src/tests/test-api.cc
@@ -18,7 +18,7 @@ TEST_F(ApiTest, Api_Board)
         std::vector<int> expected(9, player.api->game_state().NO_PLAYER);
         EXPECT_EQ(board, expected);
 
-        player.api->game_state().set_player_turn(player.id, true);
+        player.api->game_state().set_player_can_play(player.id, true);
         if (player.id == PLAYER_1)
         {
             EXPECT_EQ(OK, player.api->play(position{0, 0}));
@@ -39,7 +39,7 @@ TEST_F(ApiTest, Api_Cancel)
     for (auto& player : players)
     {
         EXPECT_FALSE(player.api->cancel());
-        player.api->game_state().set_player_turn(player.id, true);
+        player.api->game_state().set_player_can_play(player.id, true);
 
         EXPECT_EQ(OK, player.api->play(position{0, 0}));
         EXPECT_EQ(player.id, player.api->board()[0]);

--- a/games/tictactoe/src/tests/test-helpers.hh
+++ b/games/tictactoe/src/tests/test-helpers.hh
@@ -30,8 +30,8 @@ protected:
 
     std::unique_ptr<GameState> st;
 
-    const int PLAYER_1 = 0;
-    const int PLAYER_2 = 1;
+    static constexpr int PLAYER_1 = 0;
+    static constexpr int PLAYER_2 = 1;
 };
 
 class ApiTest : public ::testing::Test
@@ -56,9 +56,8 @@ protected:
     };
     std::array<Player, 2> players;
 
-    // Players values are not 0 and 1, because that would be too simple
-    const int PLAYER_1 = 1337;
-    const int PLAYER_2 = 42;
+    static constexpr int PLAYER_1 = 0;
+    static constexpr int PLAYER_2 = 1;
 };
 
 class RulesTest : public ::testing::Test
@@ -75,6 +74,6 @@ protected:
 
     std::unique_ptr<Rules> rules;
 
-    const int PLAYER_1 = 3;
-    const int PLAYER_2 = 7;
+    static constexpr int PLAYER_1 = 0;
+    static constexpr int PLAYER_2 = 1;
 };

--- a/games/tictactoe/src/tests/test-helpers.hh
+++ b/games/tictactoe/src/tests/test-helpers.hh
@@ -30,8 +30,8 @@ protected:
 
     std::unique_ptr<GameState> st;
 
-    static constexpr int PLAYER_1 = 0;
-    static constexpr int PLAYER_2 = 1;
+    const int PLAYER_1 = 0;
+    const int PLAYER_2 = 1;
 };
 
 class ApiTest : public ::testing::Test
@@ -56,8 +56,8 @@ protected:
     };
     std::array<Player, 2> players;
 
-    static constexpr int PLAYER_1 = 0;
-    static constexpr int PLAYER_2 = 1;
+    const int PLAYER_1 = 0;
+    const int PLAYER_2 = 1;
 };
 
 class RulesTest : public ::testing::Test
@@ -74,6 +74,6 @@ protected:
 
     std::unique_ptr<Rules> rules;
 
-    static constexpr int PLAYER_1 = 0;
-    static constexpr int PLAYER_2 = 1;
+    const int PLAYER_1 = 0;
+    const int PLAYER_2 = 1;
 };

--- a/games/tictactoe/src/tests/test-rules.cc
+++ b/games/tictactoe/src/tests/test-rules.cc
@@ -36,10 +36,10 @@ TEST_F(RulesTest, Rules_FinishDraw)
         rules->game_state().set_cell(to_play1[idx1++], PLAYER_1);
         rules->end_of_player_turn(PLAYER_1);
 
-        if (idx1 == to_play1.size())
-            EXPECT_TRUE(rules->is_finished());
-        else
-            EXPECT_FALSE(rules->is_finished());
+        // The game is finished only after player 2 has played. There is not
+        // support for finishing a game in the middle of a round in the server
+        // loop.
+        EXPECT_FALSE(rules->is_finished());
 
         rules->start_of_player_turn(PLAYER_2);
         if (idx2 < to_play2.size())

--- a/games/tictactoe/src/tests/test-rules.cc
+++ b/games/tictactoe/src/tests/test-rules.cc
@@ -36,7 +36,7 @@ TEST_F(RulesTest, Rules_FinishDraw)
         rules->game_state().set_cell(to_play1[idx1++], PLAYER_1);
         rules->end_of_player_turn(PLAYER_1);
 
-        // The game is finished only after player 2 has played. There is not
+        // The game is finished only after player 2 has played. There is no
         // support for finishing a game in the middle of a round in the server
         // loop.
         EXPECT_FALSE(rules->is_finished());

--- a/games/tictactoe/tictactoe.yml
+++ b/games/tictactoe/tictactoe.yml
@@ -1,5 +1,6 @@
 name: tictactoe
 rules_type: turnbased
+player_count: 2
 
 constant:
   -

--- a/src/lib/net/message.hh
+++ b/src/lib/net/message.hh
@@ -40,7 +40,7 @@ struct Message
 
     // Id of the client that sent the message
     // Ignored for replies
-    uint32_t client_id;
+    int32_t client_id;
 };
 
 } // namespace net

--- a/src/lib/rules/config.hh
+++ b/src/lib/rules/config.hh
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#pragma once
+
+#include <cstdint>
+
+namespace rules {
+
+// Game-specific configuration that the server enforces
+struct Config
+{
+    // The name of the game
+    char const* name;
+    // The number of players in the game
+    int32_t player_count;
+};
+
+} // namespace rules

--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -13,6 +13,7 @@
 
 namespace rules {
 
+// TODO: refactor rules::Player to rules::Client
 struct Player final
 {
     Player() = default;

--- a/src/lib/rules/rules.cc
+++ b/src/lib/rules/rules.cc
@@ -448,7 +448,7 @@ void TurnBasedRules::spectator_loop(ClientMessenger_sptr msgr)
 
 void TurnBasedRules::server_loop(ServerMessenger_sptr msgr)
 {
-    msgr->push_id(players_.back()->id);
+    msgr->push_id(players_.size());
 
     at_start();
     at_server_start(msgr);

--- a/src/lib/rules/types.hh
+++ b/src/lib/rules/types.hh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <rules/client-messenger.hh>
+#include <rules/config.hh>
 #include <rules/options.hh>
 #include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
@@ -10,6 +11,7 @@
 namespace rules {
 
 using f_rules_init = void (*)(const Options&);
+using f_rules_config = void (*)(Config*);
 using f_rules_result = void (*)();
 
 using f_client_loop = void (*)(ClientMessenger_sptr);

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -23,10 +23,11 @@ DEFINE_string(rules, "rules.so", "Rules library");
 DEFINE_string(dump, "", "Game data dump output path");
 DEFINE_string(replay, "", "Game replay output path");
 
-Server::Server() : nb_players_(0)
+Server::Server()
 {
     rules_lib_ = std::make_unique<utils::DLL>(FLAGS_rules);
     // Get required functions from the rules library
+    rules_config = rules_lib_->get<rules::f_rules_config>("rules_config");
     rules_init = rules_lib_->get<rules::f_rules_init>("rules_init");
     server_loop = rules_lib_->get<rules::f_server_loop>("server_loop");
     rules_result = rules_lib_->get<rules::f_rules_result>("rules_result");
@@ -39,9 +40,15 @@ void Server::run()
 
     INFO("Server Started");
 
+    // The rules configure the server
+    rules_config(&config_);
+    NOTICE("Game configuration:");
+    NOTICE("- name: %s", config_.name);
+    NOTICE("- %d players", config_.player_count);
+
     // We have to wait for the required number of clients specified in the
-    // config to be met
-    wait_for_players();
+    // command line
+    wait_for_clients();
 
     // Create a messenger for sending rules messages
     msgr_ = std::make_unique<rules::ServerMessenger>(sckt_.get());
@@ -119,13 +126,23 @@ bool used_identifier(uint32_t player_id, const rules::Players& players)
     return false;
 }
 
-void Server::wait_for_players()
+void Server::wait_for_clients()
 {
     if (FLAGS_nb_clients <= 0)
         FATAL("Server started with nb_clients <= 0.");
 
+    int spectator_count = FLAGS_nb_clients - config_.player_count;
+    if (spectator_count < 0)
+        FATAL("Server must be started with at least -nb_clients %d",
+              config_.player_count);
+
+    NOTICE("Waiting for %d clients: %d players, %d spectators...",
+           FLAGS_nb_clients, config_.player_count, spectator_count);
+
     // For each client connecting, we send back a unique id
     // Clients are players or spectators
+    // Player IDs must be in [0-NB_PLAYER[
+    // Spectator IDs must be in [NB_PLAYER-NB_CLIENTS[
 
     while (players_.size() + spectators_.size() <
            static_cast<size_t>(FLAGS_nb_clients))
@@ -134,6 +151,8 @@ void Server::wait_for_players()
 
         if (!buf_req)
             continue;
+
+        NOTICE("New client");
 
         net::Message id_req;
         id_req.handle_buffer(*buf_req);
@@ -144,52 +163,80 @@ void Server::wait_for_players()
             continue;
         }
 
-        // To avoid useless message, the client_id of the request corresponds
-        // to the type of the client connecting (PLAYER, SPECTATOR, ...)
-        // and the requested client identifier.
-        int id_and_type = id_req.client_id;
-        int player_id = id_and_type / rules::MAX_PLAYER_TYPE;
-        rules::PlayerType player_type = static_cast<rules::PlayerType>(
-            id_and_type % rules::MAX_PLAYER_TYPE);
+        int32_t player_id = id_req.client_id;
+        uint32_t client_type;
+        buf_req->handle(client_type);
 
-        ++nb_players_;
-        if (player_id == 0)
+        rules::PlayerType player_type =
+            static_cast<rules::PlayerType>(client_type);
+
+        if (player_id == -1)
         {
-            player_id = nb_players_;
-            NOTICE("Client did not request an identifier, defaulting to %i",
+            // Client requests an ID from the server
+            if (player_type == rules::PLAYER)
+                player_id = players_.size();
+            else
+                player_id = config_.player_count + spectators_.size();
+
+            NOTICE("Client did not specify an identifier, picking %d",
                    player_id);
         }
 
         if (used_identifier(player_id, players_) ||
             used_identifier(player_id, spectators_))
         {
-            ERR("Client identifier %i is already used", player_id);
-            player_id = 0; // Treated by client as invalid
+            ERR("Client identifier %d is already used", player_id);
+            player_id = -1; // Treated by client as invalid
         }
 
-        auto new_player =
-            std::make_shared<rules::Player>(player_id, player_type);
-        buf_req->handle(new_player->name);
+        if (player_id < -1)
+        {
+            ERR("Client identifier %d is invalid", player_id);
+            player_id = -1; // Treated by client as invalid
+        }
+
+        if (player_type == rules::PLAYER && player_id >= config_.player_count)
+        {
+            ERR("Invalid player identifier %d > %d", player_id,
+                config_.player_count - 1);
+            player_id = -1; // Treated by client as invalid
+        }
+
+        if (player_type == rules::SPECTATOR &&
+            (player_id < config_.player_count || player_id >= FLAGS_nb_clients))
+        {
+            ERR("Spectator identifier %d invalid, expecting %d spectators",
+                player_id, spectator_count - spectators_.size());
+            player_id = -1; // Treated by client as invalid
+        }
 
         // Send the reply with a uid
-        net::Message id_rep(net::MSG_CONNECT, new_player->id);
+        net::Message id_rep(net::MSG_CONNECT, player_id);
         utils::Buffer buf_rep;
         id_rep.handle_buffer(buf_rep);
         sckt_->send(buf_rep);
 
-        // Add the player to the list
-        if (new_player->type == rules::SPECTATOR)
-            spectators_.add(new_player);
-        else
-            players_.add(new_player);
+        if (player_id == -1)
+            continue; // Do not add invalid clients
 
-        NOTICE("Client connected - id: %i - type: %s", new_player->id,
+        auto new_client = std::make_shared<rules::Player>(
+            static_cast<uint32_t>(player_id), client_type);
+        buf_req->handle(new_client->name);
+
+        // Add the player to the list
+        if (client_type == rules::SPECTATOR)
+            spectators_.add(new_client);
+        else
+            players_.add(new_client);
+
+        NOTICE("Client connected - id: %i - type: %s", new_client->id,
                rules::playertype_str(
-                   static_cast<rules::PlayerType>(new_player->type))
+                   static_cast<rules::PlayerType>(new_client->type))
                    .c_str());
     }
 
     players_.sort();
+    spectators_.sort();
 
     // Then send players info to all clients
     utils::Buffer buf_players;

--- a/src/server/server.cc
+++ b/src/server/server.cc
@@ -129,11 +129,11 @@ bool used_identifier(uint32_t player_id, const rules::Players& players)
 void Server::wait_for_clients()
 {
     if (FLAGS_nb_clients <= 0)
-        FATAL("Server started with nb_clients <= 0.");
+        FATAL("Server started with --nb_clients <= 0.");
 
     int spectator_count = FLAGS_nb_clients - config_.player_count;
     if (spectator_count < 0)
-        FATAL("Server must be started with at least -nb_clients %d",
+        FATAL("Server must be started with at least --nb_clients %d",
               config_.player_count);
 
     NOTICE("Waiting for %d clients: %d players, %d spectators...",

--- a/src/server/server.hh
+++ b/src/server/server.hh
@@ -21,18 +21,19 @@ public:
 private:
     void sckt_init();
     void sckt_close();
-    void wait_for_players();
+    void wait_for_clients();
     std::shared_ptr<std::ostream> replay_init();
     void replay_save_results(std::shared_ptr<std::ostream> replay_stream);
 
+    rules::f_rules_config rules_config;
     rules::f_rules_init rules_init;
     rules::f_rules_result rules_result;
     rules::f_server_loop server_loop;
 
 private:
-    uint32_t nb_players_;
     std::unique_ptr<utils::DLL> rules_lib_;
 
+    rules::Config config_;
     rules::Players players_;
     rules::Players spectators_;
     rules::ServerMessenger_sptr msgr_;

--- a/tools/generator/templates/rules/src/entry.cc.jinja2
+++ b/tools/generator/templates/rules/src/entry.cc.jinja2
@@ -19,6 +19,12 @@ static Rules* rules_;
 
 extern "C" {
 
+void rules_config(rules::Config* cfg)
+{
+    cfg->name = "{{ game.name }}";
+    cfg->player_count = {{ game.player_count }};
+}
+
 void rules_init(const rules::Options& opt)
 {
     utils::Logger::get().level() = (utils::Logger::DisplayLevel)opt.verbose;

--- a/tools/stechec2-run
+++ b/tools/stechec2-run
@@ -234,18 +234,18 @@ def stechec2_run(args, options):
     # Start clients, then spectators
     client_id = 0
     for i, lib_so in enumerate(clients):
-        client_id += 1
         lib_so = os.path.expanduser(lib_so)
         try:
             name = client_names[i]
         except IndexError:
             name = 'client-{}'.format(i + 1)
         run_client(client_id, lib_so, name, False, args.isolate)
+        client_id += 1
 
     for i, lib_so in enumerate(spectators):
-        client_id += 1
         lib_so = os.path.expanduser(lib_so)
         run_client(client_id, lib_so, 'spectator-{}'.format(i + 1), True)
+        client_id += 1
 
     # Wait them all
     while poll:


### PR DESCRIPTION
Fixes #67 

This PR introduces a new exported function: rules_config(). It enable the game to specify the number of expected players. With that information, the server can allocate the player client_ids to be in natural order: the first player will have id 0, second 1, etc. This will introduce the guarantee that player ids can be used as vector indices (0-indexed and contiguous), and therefore simplify games logic.