### PR TITLE
add missing include in rules/src/entry.cc

### DIFF
--- a/tools/generator/templates/rules/src/entry.cc.jinja2
+++ b/tools/generator/templates/rules/src/entry.cc.jinja2
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <memory>
 #include <rules/client-messenger.hh>
+#include <rules/config.hh>
 #include <rules/replay-messenger.hh>
 #include <rules/server-messenger.hh>
 #include <utils/log.hh>


### PR DESCRIPTION
This include is required at [line 22](https://github.com/prologin/stechec2/compare/missing-rule-include?expand=1#diff-e1d7e9f064676a754e1c653c826b4c44L22) to get definition of `rules::Config`.