### PR TITLE
waf: generate the player environment in /usr/share

### DIFF
--- a/tools/generator/templates/rules/wscript.jinja2
+++ b/tools/generator/templates/rules/wscript.jinja2
@@ -5,6 +5,8 @@
 import glob
 import os.path
 
+from wafgenerator import generator_player_install
+
 
 def options(opt):
     pass
@@ -55,3 +57,5 @@ def build(bld):
     bld.install_files('${PREFIX}/share/stechec2/{{ game.name }}', [
         '{{ game.name }}.yml',
     ])
+
+    generator_player_install(bld, '{{ game.name }}')

--- a/tools/waf/wafgenerator.py
+++ b/tools/waf/wafgenerator.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+
+
+def generator_player_install(bld, game):
+    project_root = os.path.dirname(str(bld.bldnode))
+
+    bld.env.env = dict(os.environ)
+    bld.env.env['PYTHONPATH'] = os.path.join(project_root, 'tools')
+    bld(
+        rule='python3 -m generator player ${SRC} ${TGT}',
+        source='{}.yml'.format(game),
+        target='player',
+        always=True,
+    )
+    start_dir = bld.bldnode.find_dir('games/{}'.format(game))
+    bld.install_files('${PREFIX}/share/stechec2/' + game,
+                      start_dir.ant_glob('player/**/*'),
+                      relative_trick=True, cwd=start_dir)


### PR DESCRIPTION
This will allow to install the player environment as part of the game packages instead of having to generate them manually in /usr.