### PR TITLE
rules: introduce the --stats flag

### DIFF
--- a/src/lib/rules/player.hh
+++ b/src/lib/rules/player.hh
@@ -41,6 +41,7 @@ struct Player final
     int32_t score;
     uint32_t nb_timeout;
     std::string name;
+    std::vector<double> turn_duration_ms;
 };
 
 class Players final : public utils::IBufferizable

--- a/src/lib/rules/rules.hh
+++ b/src/lib/rules/rules.hh
@@ -2,6 +2,8 @@
 // Copyright (c) 2013 Association Prologin <association@prologin.org>
 #pragma once
 
+#include <unordered_map>
+
 #include <utils/log.hh>
 
 #include "action.hh"
@@ -75,6 +77,9 @@ public:
     // file
     void save_player_actions(Actions* actions);
 
+    // Called when the game is finished to write the stats
+    void write_stats() const;
+
 protected:
     bool is_spectator(uint32_t id);
 
@@ -90,6 +95,10 @@ protected:
     Players spectators_;
 
     int timeout_;
+
+    // Key: metric name, value: metric value.
+    // Usage: metrics_["my_metric_total"] += 1;
+    std::unordered_map<std::string, double> metrics_;
 };
 
 class SynchronousRules : public Rules


### PR DESCRIPTION
When used, the --stats FILE instructs stechec2-{server,client} to write
stats about the match to the specified file.

Currently collected stats:

* Player turn duration
* Total count of actions

Rules can add custom metrics to their local Rules::metrics_ instance
attribute.

For now only double-valued metrics can be collected.

Example stats output for a tictactoe server:

    - metrics:
      - actions_total: 6
    - player:
      - id: 0
      - name: anonymous
      - turn_duration:
        - 0.801743
        - 0.377152
        - 0.348772
    - player:
      - id: 1
      - name: anonymous
      - turn_duration:
        - 1.38622
        - 0.395657
        - 0.31234

Bug #42