### PR TITLE
Python generator: use typed NamedTuples

### DIFF
--- a/tools/generator/filters/python.py
+++ b/tools/generator/filters/python.py
@@ -5,6 +5,21 @@ from .common import generic_comment, get_array_inner, is_array
 
 
 @register_filter
+def python_type(val: str) -> str:
+    base_types = {
+        'void': 'None',
+        'int': 'int',
+        'double': 'float',
+        'string': 'str',
+    }
+    if val in base_types:
+        return base_types[val]
+    if is_array(val):
+        return 'List[{}]'.format(python_type(get_array_inner(val)))
+    return val
+
+
+@register_filter
 def python_prototype(func) -> str:
     return 'def {}({}):'.format(
         func['fct_name'],

--- a/tools/generator/templates/player/python/api.py.jinja2
+++ b/tools/generator/templates/player/python/api.py.jinja2
@@ -3,7 +3,7 @@
 # {{ stechec2_generated }}
 
 from enum import IntEnum
-from collections import namedtuple
+from typing import NamedTuple, List
 
 from _api import *
 
@@ -29,11 +29,10 @@ class {{ enum.enum_name }}(IntEnum):
 {% for struct in game.struct %}
     {% if not struct.str_tuple %}
 {{ struct.str_summary|python_comment }}
-{{ struct.str_name }} = namedtuple('{{ struct.str_name }}', [
+class {{ struct.str_name }}(NamedTuple):
     {% for field_name, field_type, field_comment in struct.str_field %}
-    '{{ field_name }}',  # {{ field_comment }}
+    {{ field_name }}: {{ field_type|python_type }}  # {{ field_comment }}
     {% endfor %}
-])
 
 
     {% endif %}

--- a/tools/generator/templates/texdoc/useapi.tex.jinja2
+++ b/tools/generator/templates/texdoc/useapi.tex.jinja2
@@ -106,7 +106,7 @@ fonctionACompleter = do
       importé par défaut par le code à compléter ;}
 \item{Les énumérations sont représentées par des \texttt{IntEnum} Python, qui
       peuvent être utilisées comme ceci : \texttt{nom\_enum.CHAMP}. ;}
-\item{Les structures sont représentées par des \texttt{namedtuple} Python, dont
+\item{Les structures sont représentées par des \texttt{NamedTuple} Python, dont
       on peut accéder aux champs via la notation pointée habituelle, et
       qui peuvent être créés comme ceci : \texttt{foo(bar=42, x=3)}, sauf pour
       la structure \texttt{position} qui est représentée par un couple (x, y).}


### PR DESCRIPTION
New API output looks like this:

```python
# This file was generated by stechec2-generator. DO NOT EDIT.

from enum import IntEnum
from typing import NamedTuple, List

from _api import *


# Constant value
CONST_VAL = 42

# Floating point constant
CONST_DOUBLE = 42.42


# Enumeration containing several values to test for.
class test_enum(IntEnum):
    VAL1 = 0  # <- value 1
    VAL2 = 1  # <- value 2


# Simple structure with nothing special.
class simple_struct(NamedTuple):
    field_i: int  # Integer field
    field_bool: bool  # Bool field
    field_double: float  # Double field


# Structure which contains an array.
class struct_with_array(NamedTuple):
    field_int: int  # Integer field
    field_int_arr: List[int]  # Integer array field
    field_str_arr: List[simple_struct]  # Structure array field


# Structure which contains an other struct
class struct_with_struct(NamedTuple):
    field_integer: int  # Integer field
    field_struct: simple_struct  # Structure field
```

Used to be this:

```python
# Simple structure with nothing special.
simple_struct = namedtuple('simple_struct', [
    'field_i',  # Integer field
    'field_bool',  # Bool field
    'field_double',  # Double field
])


# Structure which contains an array.
struct_with_array = namedtuple('struct_with_array', [
    'field_int',  # Integer field
    'field_int_arr',  # Integer array field
    'field_str_arr',  # Structure array field
])


# Structure which contains an other struct
struct_with_struct = namedtuple('struct_with_struct', [
    'field_integer',  # Integer field
    'field_struct',  # Structure field
])
```