### PR TITLE
Use shared pointer to the gamestate in the API

### DIFF
--- a/games/plusminus/src/api.cc
+++ b/games/plusminus/src/api.cc
@@ -9,7 +9,7 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state,
+Api::Api(std::shared_ptr<GameState> game_state,
          std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {

--- a/games/plusminus/src/api.hh
+++ b/games/plusminus/src/api.hh
@@ -20,7 +20,7 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state,
+    Api(std::shared_ptr<GameState> game_state,
         std::shared_ptr<rules::Player> player);
     ~Api() {}
 

--- a/games/tictactoe/src/api.cc
+++ b/games/tictactoe/src/api.cc
@@ -10,7 +10,7 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state,
+Api::Api(std::shared_ptr<GameState> game_state,
          std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {

--- a/games/tictactoe/src/api.hh
+++ b/games/tictactoe/src/api.hh
@@ -18,7 +18,7 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state,
+    Api(std::shared_ptr<GameState> game_state,
         std::shared_ptr<rules::Player> player);
 
     /// Play at the given position

--- a/src/lib/rules/actions.hh
+++ b/src/lib/rules/actions.hh
@@ -15,8 +15,8 @@ namespace rules
 
 class Actions : public utils::IBufferizable
 {
-    using ActionFactory = std::function<std::unique_ptr<IAction>()>;
-    using ActionLog = std::vector<std::unique_ptr<IAction>>;
+    using ActionFactory = std::function<std::shared_ptr<IAction>()>;
+    using ActionLog = std::vector<std::shared_ptr<IAction>>;
 
 public:
     static constexpr size_t MAX_ACTIONS = 1024;
@@ -28,7 +28,7 @@ public:
     // Serialization/Unserialization
     void handle_buffer(utils::Buffer& buf) override;
 
-    void add(std::unique_ptr<IAction> action)
+    void add(std::shared_ptr<IAction> action)
     {
         if (actions_.size() >= MAX_ACTIONS)
             FATAL("Too many actions (>%d) sent during this turn.", MAX_ACTIONS);

--- a/src/lib/rules/api.hh
+++ b/src/lib/rules/api.hh
@@ -34,7 +34,7 @@ protected:
         ApiError call(Args&&... args)
         {
             // Build action object
-            auto action = std::make_unique<Action>(std::forward<Args>(args)...,
+            auto action = std::make_shared<Action>(std::forward<Args>(args)...,
                                                    api_->player_->id);
 
             // Check action
@@ -69,7 +69,7 @@ protected:
     };
 
 public:
-    Api(std::unique_ptr<GameState> game_state, std::shared_ptr<Player> player)
+    Api(std::shared_ptr<GameState> game_state, std::shared_ptr<Player> player)
         : game_state_(std::move(game_state))
         , player_(player)
     {

--- a/src/lib/rules/game-state-history.hh
+++ b/src/lib/rules/game-state-history.hh
@@ -20,7 +20,7 @@ class GameStateHistory
                   "GameState not derived from rules::GameState");
 
 public:
-    GameStateHistory(std::unique_ptr<GameState> current)
+    GameStateHistory(std::shared_ptr<GameState> current)
         : current_(std::move(current))
     {
     }
@@ -66,7 +66,7 @@ public:
     }
 
 private:
-    std::unique_ptr<GameState> current_;
-    std::vector<std::unique_ptr<GameState>> versions_;
+    std::shared_ptr<GameState> current_;
+    std::vector<std::shared_ptr<GameState>> versions_;
 };
 } // namespace rules

--- a/tools/generator/templates/rules/src/api.cc.jinja2
+++ b/tools/generator/templates/rules/src/api.cc.jinja2
@@ -9,7 +9,7 @@
 // global used in interface.cc
 Api* api;
 
-Api::Api(std::unique_ptr<GameState> game_state,
+Api::Api(std::shared_ptr<GameState> game_state,
          std::shared_ptr<rules::Player> player)
     : rules::Api<GameState, error>(std::move(game_state), player)
 {

--- a/tools/generator/templates/rules/src/api.hh.jinja2
+++ b/tools/generator/templates/rules/src/api.hh.jinja2
@@ -21,7 +21,7 @@
 class Api final : public rules::Api<GameState, error>
 {
 public:
-    Api(std::unique_ptr<GameState> game_state,
+    Api(std::shared_ptr<GameState> game_state,
         std::shared_ptr<rules::Player> player);
     ~Api() {}
 


### PR DESCRIPTION
When using `unique_ptr`, we are not allowed to materialize two APIs that interact with the same game state. This is painful when writing tests as it makes it harder to simulate proper interactions between the players.

For examples, in tests for the past 4 years, `test-helpers.hh` gives access to two players, playing in two separate worlds:

 - (2019) https://github.com/prologin/prologin2019/blob/master/src/tests/test-helpers.hh#L104-L109
 - (2018) https://github.com/prologin/prologin2018/blob/master/src/tests/test-helpers.hh#L113-L118
 - (2017) https://github.com/prologin/prologin2017/blob/master/src/tests/test-helpers.hh#L51-L56
 - (2016) https://github.com/prologin/prologin2016/blob/master/src/tests/test-helpers.hh#L67-L71

Also note that this is breaking change, if this change seems fine I'll need to update code of past editions.