### PR TITLE
Augment the number of dumps and give them timestamp

### DIFF
--- a/src/lib/rules/rules.hh
+++ b/src/lib/rules/rules.hh
@@ -2,6 +2,8 @@
 // Copyright (c) 2013 Association Prologin <association@prologin.org>
 #pragma once
 
+#include <map>
+#include <string>
 #include <utils/log.hh>
 
 #include "action.hh"
@@ -65,7 +67,7 @@ public:
     virtual void end_of_round() {}
 
     // Called at every turn by the server to dump the gamestate in the dumpfile
-    virtual void dump_state(std::ostream&)
+    virtual void dump_state(std::ostream&, std::map<std::string, int>)
     {
         FATAL("dump_state() virtual function not implemented in the rules "
               "but the server was launched with the `--dump` option.");
@@ -78,10 +80,10 @@ public:
 protected:
     bool is_spectator(uint32_t id);
 
-    void dump_state_stream()
+    void dump_state_stream(std::map<std::string, int> timestamp)
     {
         if (opt_.dump_stream)
-            dump_state(*opt_.dump_stream);
+            dump_state(*opt_.dump_stream, timestamp);
     }
 
     Options opt_;

--- a/src/lib/rules/rules.hh
+++ b/src/lib/rules/rules.hh
@@ -2,8 +2,6 @@
 // Copyright (c) 2013 Association Prologin <association@prologin.org>
 #pragma once
 
-#include <map>
-#include <string>
 #include <utils/log.hh>
 
 #include "action.hh"
@@ -66,25 +64,12 @@ public:
     virtual void start_of_round() {}
     virtual void end_of_round() {}
 
-    // Called at every turn by the server to dump the gamestate in the dumpfile
-    virtual void dump_state(std::ostream&, std::map<std::string, int>)
-    {
-        FATAL("dump_state() virtual function not implemented in the rules "
-              "but the server was launched with the `--dump` option.");
-    }
-
     // Called after every turn to save the actions of the player to the replay
     // file
     void save_player_actions(Actions* actions);
 
 protected:
     bool is_spectator(uint32_t id);
-
-    void dump_state_stream(std::map<std::string, int> timestamp)
-    {
-        if (opt_.dump_stream)
-            dump_state(*opt_.dump_stream, timestamp);
-    }
 
     Options opt_;
 


### PR DESCRIPTION
The goal is to add a notion of timestamp to the creation of a dump,
that would describe the round, the player and the action if there are
some. It comes with doing dumps much more often.

The use of a map is only a proof of concept to launch some discussion,
as it gives quite a lot of flexibility for what the timestamp can
represent.