### PR TITLE
Rust: fix rust deps + more `Copy` structs

### DIFF
--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -159,15 +159,10 @@ def rust_auto_traits(ctx, value: str) -> set:
     as_struct = ctx['game'].get_struct(value)
 
     if as_struct:
-        inherited = set.intersection(*(
+        return set.intersection(*(
             rust_auto_traits(ctx, field_type)
             for _, field_type, _ in as_struct['str_field']
         ))
-
-        if not is_tuple(as_struct) and 'Copy' in inherited:
-            inherited.remove('Copy')
-
-        return inherited
 
     if is_array(value):
         inherited = rust_auto_traits(ctx, get_array_inner(value))

--- a/tools/generator/templates/player/rust/Makefile-rust.jinja2
+++ b/tools/generator/templates/player/rust/Makefile-rust.jinja2
@@ -14,7 +14,7 @@ LDFLAGS = -lm -lrt -ldl -lpthread -lstdc++
 {% block extra_rules %}
 objs += champion.a
 
-champion.a:
+champion.a: $(CHAMPION_SRC)
 	rustc --crate-type=staticlib $(RUSTC_FLAGS) --emit link,dep-info=.champion.a.d champion.rs -o champion.a
 
 deps = $(cxx_sources:.cc=.d) champion.a.d

--- a/tools/generator/templates/player/rust/Makefile-rust.jinja2
+++ b/tools/generator/templates/player/rust/Makefile-rust.jinja2
@@ -14,7 +14,7 @@ LDFLAGS = -lm -lrt -ldl -lpthread -lstdc++
 {% block extra_rules %}
 objs += champion.a
 
-champion.a: $(CHAMPION_SRC)
+champion.a: $(filter %.rs %.rs,$(CHAMPION_FILES))
 	rustc --crate-type=staticlib $(RUSTC_FLAGS) --emit link,dep-info=.champion.a.d champion.rs -o champion.a
 
 deps = $(cxx_sources:.cc=.d) champion.a.d

--- a/tools/generator/templates/player/rust/Makefile.jinja2
+++ b/tools/generator/templates/player/rust/Makefile.jinja2
@@ -3,11 +3,10 @@
  #}
 # Add all your champion files in here, separated by spaces
 # Include all the sources (*.rs) and README files.
-CHAMPION_SRC = champion.rs
+CHAMPION_FILES = champion.rs
 
 # ----
 # Do not modify the lines below
 
-CHAMPION_SRC += api.rs
-CHAMPION_FILES += $(CHAMPION_SRC) ffi.rs api.hh interface.cc
+CHAMPION_FILES += api.rs ffi.rs api.hh interface.cc
 -include Makefile-rust

--- a/tools/generator/templates/player/rust/Makefile.jinja2
+++ b/tools/generator/templates/player/rust/Makefile.jinja2
@@ -3,10 +3,11 @@
  #}
 # Add all your champion files in here, separated by spaces
 # Include all the sources (*.rs) and README files.
-CHAMPION_FILES = champion.rs
+CHAMPION_SRC = champion.rs
 
 # ----
 # Do not modify the lines below
 
-CHAMPION_FILES += api.rs ffi.rs api.hh interface.cc
+CHAMPION_SRC += api.rs
+CHAMPION_FILES += $(CHAMPION_SRC) ffi.rs api.hh interface.cc
 -include Makefile-rust


### PR DESCRIPTION
This combines two little changes:

 - `make` will actually rebuild the champion when it is modified
 - most struct in the API will implement `Copy`