### PR TITLE
rust: strings are not Copy

### DIFF
--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -175,5 +175,9 @@ def rust_auto_traits(ctx, value: str) -> set:
     if value == 'double':
         return {'Copy', 'Clone', 'Debug', 'PartialEq', 'PartialOrd'}
 
+    if value == 'string':
+        return {'Clone', 'Debug', 'Eq', 'Hash', 'Ord', 'PartialEq',
+                'PartialOrd'}
+
     return {'Copy', 'Clone', 'Debug', 'Eq', 'Hash', 'Ord', 'PartialEq',
             'PartialOrd'}


### PR DESCRIPTION
Structures containing a string would try to auto-implement Copy.