### PR TITLE
rust: allow both borrowed and owning types for array inputs

### DIFF
--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -118,8 +118,9 @@ def rust_api_input_type(
         if get_array_inner(value) == 'string':
             return '&[impl AsRef<str>]'
         else:
-            inner = rust_api_input_type(ctx, get_array_inner(value), skip_ref=True)
-            return '&[impl Borrow<{}>]'.format(inner)
+            return '&[impl Borrow<{}>]'.format(
+                rust_api_input_type(ctx, get_array_inner(value), skip_ref=True)
+            )
     elif as_struct and is_tuple(as_struct):
         return '({})'.format(
             ', '.join(

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -8,13 +8,13 @@
 // do not touch the part where constants, enums, structs, and api functions are
 // defined.
 
-//! Rust API for {{ game.name }}
+//! Rust API for {{ game.name }}
 
 use crate::ffi;
-use crate::ffi::{CToRust, RustToC};
+use crate::ffi::{array_of_borrow_to_c, CToRust, RustToC};
 
 #[allow(unused_imports)]
-use std::cell::UnsafeCell;
+use std::{cell::UnsafeCell, borrow::Borrow};
 
 {% for constant in game.constant %}
 {{ constant.cst_comment|cxx_comment(doc=True) }}
@@ -48,16 +48,18 @@ pub struct {{ struct.str_name|camel_case }} {
 ///
 /// ### Parameters
 {% for name, _, comment in func.fct_arg %}
-///  - `{{ name }}`: {{ comment }}
+///  - `{{ name }}`: {{ comment }}
 {% endfor %}
 {% endif %}
 pub {{ func|rust_prototype }} {
     unsafe {
         {% for arg, type, _ in func.fct_arg %}
         {% if type|rust_is_copy %}
-        let {{ arg }} = {{ arg }}.to_c();
+        let {{ arg }} = {{ arg }}.to_c();
+        {% elif type is array %}
+        let {{ arg }} = UnsafeCell::new(array_of_borrow_to_c({{ arg }}));
         {% else %}
-        let {{ arg }} = UnsafeCell::new({{ arg }}.to_c());
+        let {{ arg }} = UnsafeCell::new({{ arg }}.to_c());
         {% endif %}
         {% endfor %}
         ffi::{{ func|rust_ffi_call }}.to_rust()

--- a/tools/generator/templates/player/rust/ffi.rs.jinja2
+++ b/tools/generator/templates/player/rust/ffi.rs.jinja2
@@ -11,9 +11,10 @@
 
 use crate::api;
 
+use std::borrow::Borrow;
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_double, c_int, c_void};
 use std::{mem::{drop, size_of}, ptr, slice};
+use std::os::raw::{c_char, c_double, c_int, c_void};
 
 #[allow(non_camel_case_types)]
 pub type c_bool = bool;
@@ -144,6 +145,20 @@ where
 
 // Conversions for array
 
+pub unsafe fn array_of_borrow_to_c<T, U, V>(data: &[T]) -> Array<V>
+where
+    T: Borrow<U>,
+    U: RustToC<V>,
+{
+    let ptr = malloc(data.len() * size_of::<V>()) as *mut V;
+
+    for (i, item) in data.iter().enumerate() {
+        ptr::write(ptr.add(i), item.borrow().to_c());
+    }
+
+    Array { ptr, len: data.len() }
+}
+
 impl<T, U> CToRust<Vec<U>> for Array<T>
 where
     T: CToRust<U>,
@@ -161,13 +176,7 @@ where
     T: RustToC<U>,
 {
     unsafe fn to_c(&self) -> Array<U> {
-        let ptr = malloc(self.len() * size_of::<U>()) as *mut U;
-
-        for (i, item) in self.iter().enumerate() {
-            ptr::write(ptr.add(i), item.to_c());
-        }
-
-        Array { ptr, len: self.len() }
+        array_of_borrow_to_c(self)
     }
 }
 

--- a/tools/generator/test/languages/champion.rs
+++ b/tools/generator/test/languages/champion.rs
@@ -17,23 +17,23 @@ pub fn test() {
     send_me_tau(6.2831853);
     send_me_joseph_marchand("Joseph Marchand");
     send_me_13_ints(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);
-    assert!(returns_42() == 42);
-    assert!(returns_true() == true);
+    assert_eq!(returns_42(), 42);
+    assert_eq!(returns_true(), true);
+    assert_eq!(returns_joseph_marchand(), "Joseph Marchand");
+    assert_eq!(returns_val1(), TestEnum::Val1);
     assert!((returns_tau() - 6.2831).abs() < 0.001);
-    assert!(returns_joseph_marchand() == "Joseph Marchand");
-    assert!(returns_val1() == TestEnum::Val1);
 
     let r = returns_range(1, 100);
-    assert!(r == (1..100).collect::<Vec<_>>());
+    assert_eq!(r, (1..100).collect::<Vec<_>>());
 
     let r = returns_range(1, 10000);
-    assert!(r == (1..10000).collect::<Vec<_>>());
+    assert_eq!(r, (1..10000).collect::<Vec<_>>());
 
     let v = returns_sorted(&[1, 3, 2, 4, 5, 7, 6]);
-    assert!(v == (1..8).collect::<Vec<_>>());
+    assert_eq!(v, (1..8).collect::<Vec<_>>());
 
     let ba = returns_not(&vec![true, false, false, true, false, false, true, false, false]);
-    assert!(ba == vec![false, true, true, false, true, true, false, true, true]);
+    assert_eq!(ba, vec![false, true, true, false, true, true, false, true, true]);
 
     let bdo = &vec![-0.5, 1.0, 12.5, 42.0];
     let bdi = returns_inverse(bdo);
@@ -43,9 +43,11 @@ pub fn test() {
 
     let sa = ["Alea", "Jacta", "Est"];
     let sau = returns_upper(&sa);
-    assert!(sau[0] == "ALEA");
-    assert!(sau[1] == "JACTA");
-    assert!(sau[2] == "EST");
+    assert_eq!(sau, vec!["ALEA", "JACTA", "EST"]);
+
+    let sa: Vec<_> = sa.iter().map(|s| s.to_string()).collect();
+    let sau = returns_upper(&sa);
+    assert_eq!(sau, vec!["ALEA", "JACTA", "EST"]);
 
     let simple = SimpleStruct {
         field_i: 42,
@@ -74,7 +76,10 @@ pub fn test() {
         };
         42
     ];
-
     let lr = send_me_struct_array(&l);
-    assert!(l == lr);
+    assert_eq!(l, lr);
+
+    let l_with_refs: Vec<&StructWithArray> = l.iter().collect();
+    let lr = send_me_struct_array(&l_with_refs);
+    assert_eq!(l, lr);
 }

--- a/tools/generator/test/languages/champion.rs
+++ b/tools/generator/test/languages/champion.rs
@@ -41,11 +41,8 @@ pub fn test() {
         assert!(bdi[i] - (1. / bdo[i]) < 0.0001);
     }
 
-    let sa: Vec<String> = ["Alea", "Jacta", "Est"].iter().map(|s| s.to_string()).collect();
-    let sau: Vec<String> = returns_upper(&sa);
-    println!("{}", sau[0]);
-    println!("{}", sau[1]);
-    println!("{}", sau[2]);
+    let sa = ["Alea", "Jacta", "Est"];
+    let sau = returns_upper(&sa);
     assert!(sau[0] == "ALEA");
     assert!(sau[1] == "JACTA");
     assert!(sau[2] == "EST");


### PR DESCRIPTION
This should help avoiding to perform conversions no matter what is the inner representation used by candidates. For example with strings, both of these usages are valid:

```rust
let input: [&str] = ["str 1", "str 2", "str 3"];
give_me_an_array(&input);
```

```rust
let input: Vec<String> = (1..=3).map(|x| format!("str {}", x)).collect();
give_me_an_array(&input);
```

**NOTE**: we could go even further by allowing any iterator as an input

```rust
let input = (1..=3).map(|x| format!("str {}", x));
give_me_an_array(&input);
```

However I don't think it would be a good idea.

~**NOTE**: I'll return back to work but I haven't had time to properly test how it behaves on various cases (for example with array of structs ?)~