### PR TITLE
rules: Action: Add a virtual method dump_json

### DIFF
--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <vector>
 
@@ -28,7 +29,7 @@ public:
     virtual void apply(GameState* st) const = 0;
 
     // Outputs to a stream the json dump of the action.
-    virtual void dump_json(const GameState& st) const;
+    virtual void dump_json(const GameState& st, std::ostream& ss) const;
 
     // Handles serialization and deserialization of the Action object to a
     // buffer.
@@ -69,10 +70,10 @@ public:
     }
 
     // Outputs to a stream the json dump of the action.
-    virtual void dump_json(const TState& st) const;
-    void dump_json(const GameState& st) const override
+    virtual void dump_json(const TState& st, std::ostream& ss) const;
+    void dump_json(const GameState& st, std::ostream& ss) const override
     {
-        return dump_json(static_cast<const TState&>(st));
+        return dump_json(static_cast<const TState&>(st), ss);
     }
 };
 

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -70,7 +70,7 @@ public:
     }
 
     // Outputs to a stream the json dump of the action.
-    virtual void dump_json(const TState& st, std::ostream& ss) const
+    virtual void dump_json(const TState& /* st */, std::ostream& /* ss */) const
     {
     }
 

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -27,6 +27,9 @@ public:
     // Apply action to game state.
     virtual void apply(GameState* st) const = 0;
 
+    // Outputs to a stream the json dump of the action.
+    virtual void dump_json(const GameState& st) const;
+
     // Handles serialization and deserialization of the Action object to a
     // buffer.
     virtual void handle_buffer(utils::Buffer& buf) = 0;
@@ -63,6 +66,13 @@ public:
     void apply(std::unique_ptr<TState>& st) const
     {
         apply_on(st.get());
+    }
+
+    // Outputs to a stream the json dump of the action.
+    virtual void dump_json(const TState& st) const;
+    void dump_json(const GameState& st) const override
+    {
+        return dump_json(static_cast<const TState&>(st));
     }
 };
 

--- a/src/lib/rules/action.hh
+++ b/src/lib/rules/action.hh
@@ -29,7 +29,7 @@ public:
     virtual void apply(GameState* st) const = 0;
 
     // Outputs to a stream the json dump of the action.
-    virtual void dump_json(const GameState& st, std::ostream& ss) const;
+    virtual void dump_json(const GameState& st, std::ostream& ss) const = 0;
 
     // Handles serialization and deserialization of the Action object to a
     // buffer.
@@ -70,10 +70,13 @@ public:
     }
 
     // Outputs to a stream the json dump of the action.
-    virtual void dump_json(const TState& st, std::ostream& ss) const;
+    virtual void dump_json(const TState& st, std::ostream& ss) const
+    {
+    }
+
     void dump_json(const GameState& st, std::ostream& ss) const override
     {
-        return dump_json(static_cast<const TState&>(st), ss);
+        dump_json(static_cast<const TState&>(st), ss);
     }
 };
 

--- a/tools/generator/templates/rules/src/action_template.cc.jinja2
+++ b/tools/generator/templates/rules/src/action_template.cc.jinja2
@@ -13,3 +13,8 @@ void Action{{ action.fct_name|camel_case }}::apply_on(GameState* st) const
 {
     // FIXME
 }
+
+void Action{{ action.fct_name|camel_case }}::dump_json(const GameState& st) const
+{
+    // FIXME: optional function that dumps the action
+}

--- a/tools/generator/templates/rules/src/action_template.cc.jinja2
+++ b/tools/generator/templates/rules/src/action_template.cc.jinja2
@@ -14,7 +14,7 @@ void Action{{ action.fct_name|camel_case }}::apply_on(GameState* st) const
     // FIXME
 }
 
-void Action{{ action.fct_name|camel_case }}::dump_json(const GameState& st) const
+void Action{{ action.fct_name|camel_case }}::dump_json(const GameState& st, std::ostream& ss) const
 {
     // FIXME: optional function that dumps the action
 }

--- a/tools/generator/templates/rules/src/action_template.hh.jinja2
+++ b/tools/generator/templates/rules/src/action_template.hh.jinja2
@@ -23,7 +23,7 @@ public:
 
     int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
-    void dump_json(const GameState& st) const;
+    void dump_json(const GameState& st, std::ostream& ss) const;
 
     void handle_buffer(utils::Buffer& buf) override
     {

--- a/tools/generator/templates/rules/src/action_template.hh.jinja2
+++ b/tools/generator/templates/rules/src/action_template.hh.jinja2
@@ -23,6 +23,7 @@ public:
 
     int check(const GameState& st) const override;
     void apply_on(GameState* st) const override;
+    void dump_json(const GameState& st) const;
 
     void handle_buffer(utils::Buffer& buf) override
     {
@@ -39,4 +40,3 @@ private:
     {{ arg_type }} {{ arg_name }}_;
     {% endfor %}
 };
-


### PR DESCRIPTION
Add an optional virtual method to output the json dump for an action, in
order to make the dump process more elegant for the rules that use this feature.

This way for the list of actions to dump you can just call `action.dump_json(gamestate)`.