### PR TITLE
generator: python: fix tuple handling in python_add()

### DIFF
--- a/tools/generator/templates/player/python/api.py.jinja2
+++ b/tools/generator/templates/player/python/api.py.jinja2
@@ -3,7 +3,7 @@
 # {{ stechec2_generated }}
 
 from enum import IntEnum
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Tuple  # noqa: F401
 
 from _api import *
 


### PR DESCRIPTION
Diff from gendiff on prologin2019.yml:

```diff
diff --git tmp/stechec2-gendiff-gen-yhp732ce/python/api.py tmp/stechec2-gendiff-gen-ukje5g9k/python/api.py
index d62673f..9b4b6e6 100644
--- tmp/stechec2-gendiff-gen-yhp732ce/python/api.py
+++ tmp/stechec2-gendiff-gen-ukje5g9k/python/api.py
@@ -1,7 +1,7 @@
 # This file was generated by stechec2-generator. DO NOT EDIT.
 
 from enum import IntEnum
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Tuple  # noqa: F401
 
 from _api import *
 
@@ -121,7 +121,7 @@ class minerai(NamedTuple):
 
 # Nain (standard)
 class nain(NamedTuple):
-    pos: position  # Position actuelle du nain (standard)
+    pos: Tuple[int, int]  # Position actuelle du nain (standard)
     vie: int  # Point(s) de vie restant du nain (standard)
     pa: int  # Point(s) d'action restant du nain (standard)
     pm: int  # Point(s) de déplacement restant du nain (standard)
```