### PR TITLE
fix missing flag `--stats` for `stechec2-server`

### DIFF
--- a/wscript
+++ b/wscript
@@ -231,6 +231,7 @@ def build_server(bld):
     bld.program(source='''
             src/server/main.cc
             src/server/server.cc
+            src/lib/rules/rules.cc
         ''',
                 target='stechec2-server',
                 defines=[


### PR DESCRIPTION
Since the flag `--stats` is defined in `rules.cc`, we need to specify it in waf sources, otherwise waf doesn't seem to properly detect it.

```
# .local/bin/stechec2-server --stats stats.yml
ERROR: unknown command line flag 'stats'
```

It appears that this branch should be run in production for use with an up to date `sadm` since this feature is already used: https://github.com/prologin/sadm/pull/178, so maybe I missed something here? Have I been confused?