### PR TITLE
Improve copyright banners in generated files.

### DIFF
--- a/tools/generator/generator.py
+++ b/tools/generator/generator.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2020 Association Prologin <association@prologin.org>
 
 import jinja2
+from datetime import date
 from pathlib import Path
 
 from .filters import load_library_in
@@ -30,7 +31,7 @@ class Generator:
         if out_name is None:
             out_name = name
         tpl = self.env.get_template(name + '.jinja2')
-        out = tpl.stream(game=self.game, **params)
+        out = tpl.stream(game=self.game, year=date.today().year, **params)
         out_path = self.out_dir / out_name
         out_path.parent.mkdir(parents=True, exist_ok=True)
         try:

--- a/tools/generator/templates/includes/Makefile-language.jinja2
+++ b/tools/generator/templates/includes/Makefile-language.jinja2
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2020 Association Prologin <association@prologin.org>
+# Copyright (c) {{ year }} Association Prologin <association@prologin.org>
 
 # When running in server mode, simply take all the files extracted from the
 # archive.

--- a/tools/generator/templates/player/c/api.h.jinja2
+++ b/tools/generator/templates/player/c/api.h.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2012-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/c.jinja2' as c %}
 
 // This file contains all the API functions for the C language, and all the

--- a/tools/generator/templates/player/c/interface.cc.jinja2
+++ b/tools/generator/templates/player/c/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 
 // This file contains the code to call the API functions from the C language.
 // {{ stechec2_generated }}

--- a/tools/generator/templates/player/caml/interface.cc.jinja2
+++ b/tools/generator/templates/player/caml/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains the code to call the API functions from the OCaml

--- a/tools/generator/templates/player/cs/api.cs.jinja2
+++ b/tools/generator/templates/player/cs/api.cs.jinja2
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
-
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2012-2021 Association Prologin <association@prologin.org>
+ #}
 
 using System.Runtime.CompilerServices;
 

--- a/tools/generator/templates/player/cs/interface.cc.jinja2
+++ b/tools/generator/templates/player/cs/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains the code to call the API functions from the C#

--- a/tools/generator/templates/player/cxx/api.hh.jinja2
+++ b/tools/generator/templates/player/cxx/api.hh.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2012-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains all the API functions for the C++ language, and all the

--- a/tools/generator/templates/player/cxx/interface.cc.jinja2
+++ b/tools/generator/templates/player/cxx/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 
 // This file contains the code to call the API functions from the C++ language.
 // {{ stechec2_generated }}

--- a/tools/generator/templates/player/haskell/Makefile.jinja2
+++ b/tools/generator/templates/player/haskell/Makefile.jinja2
@@ -1,5 +1,6 @@
-# SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 
 # Add all your sources (must be suffixed by *.hs) in here, separated by spaces
 CHAMPION_FILES = Champion.hs

--- a/tools/generator/templates/player/haskell/interface.cc.jinja2
+++ b/tools/generator/templates/player/haskell/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 
 // This file contains the code to call the API functions from the C language.
 // {{ stechec2_generated }}

--- a/tools/generator/templates/player/java/interface.cc.jinja2
+++ b/tools/generator/templates/player/java/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2005-2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2005-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains the code to call the API functions from the Java language.

--- a/tools/generator/templates/player/php/interface.cc.jinja2
+++ b/tools/generator/templates/player/php/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains the code to call the API functions from the PHP

--- a/tools/generator/templates/player/python/interface.cc.jinja2
+++ b/tools/generator/templates/player/python/interface.cc.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2020-2021 Association Prologin <association@prologin.org>
+ #}
 {% import 'macros/cxx.jinja2' as cxx %}
 
 // This file contains the code to call the API functions from the Python

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
-//
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2012-2021 Association Prologin <association@prologin.org>
+ #}
 // This file contains all the API functions for the Rust language, and all the
 // constants, enumerations and structures.
 //

--- a/tools/generator/templates/player/rust/ffi.rs.jinja2
+++ b/tools/generator/templates/player/rust/ffi.rs.jinja2
@@ -1,5 +1,6 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+{# SPDX-License-Identifier: GPL-2.0-or-later
+ # Copyright (c) 2012-2021 Association Prologin <association@prologin.org>
+ #}
 
 //! Types and conversions for the C interface
 //!

--- a/tools/generator/templates/rules/src/action_template.cc.jinja2
+++ b/tools/generator/templates/rules/src/action_template.cc.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #include "actions.hh"
 

--- a/tools/generator/templates/rules/src/action_template.hh.jinja2
+++ b/tools/generator/templates/rules/src/action_template.hh.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #pragma once
 

--- a/tools/generator/templates/rules/src/actions.hh.jinja2
+++ b/tools/generator/templates/rules/src/actions.hh.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #pragma once
 

--- a/tools/generator/templates/rules/src/api.cc.jinja2
+++ b/tools/generator/templates/rules/src/api.cc.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #include "api.hh"
 

--- a/tools/generator/templates/rules/src/api.hh.jinja2
+++ b/tools/generator/templates/rules/src/api.hh.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #pragma once
 

--- a/tools/generator/templates/rules/src/constant.hh.jinja2
+++ b/tools/generator/templates/rules/src/constant.hh.jinja2
@@ -1,7 +1,7 @@
 {% import 'macros/cxx.jinja2' as cxx -%}
 
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #pragma once
 

--- a/tools/generator/templates/rules/src/interface.cc.jinja2
+++ b/tools/generator/templates/rules/src/interface.cc.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #include <iostream>
 #include <sstream>

--- a/tools/generator/templates/rules/src/rules.cc.jinja2
+++ b/tools/generator/templates/rules/src/rules.cc.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #include "rules.hh"
 

--- a/tools/generator/templates/rules/src/rules.hh.jinja2
+++ b/tools/generator/templates/rules/src/rules.hh.jinja2
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+// Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 #pragma once
 

--- a/tools/generator/templates/rules/wscript.jinja2
+++ b/tools/generator/templates/rules/wscript.jinja2
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-2.0-or-later
-# Copyright (c) 2012-2020 Association Prologin <association@prologin.org>
+# Copyright (c) 2012-{{ year }} Association Prologin <association@prologin.org>
 
 import glob
 import os.path


### PR DESCRIPTION
Copyright notices in generated code are out of date. Additionally, whether copyright notices are included in generated files is inconsistent across all files.

For instance, `tools/generator/templates/player/c/interface.cc.jinja2` has an actual copyright notice that is included in every generated file:

```c
// SPDX-License-Identifier: GPL-2.0-or-later
// Copyright (c) 2020 Association Prologin <association@prologin.org>
```

Whereas, in the same directory, `tools/generator/templates/player/c/champion.c.jinja2` has a copyright notice that does **not** get copied to generated files:

```jinja
{# SPDX-License-Identifier: GPL-2.0-or-later #}
{# Copyright (c) 2020 Association Prologin <association@prologin.org> -#}
```

This PR changes that behavior:
1. All files in `tools/generator/templates/player` no longer output copyright banners.
2. Other files in `tools/generator/templates` (that is, in the `includes` and `rules` subdirectories) use `{{ year }}` instead of `2020` for copyright notices. This ensures that users don't have to modify the copyright banners after generating source files.

Regarding point 2, there is a small issue with this change: the `.jinja2` files themselves don't have a valid copyright banner anymore, since it contains `{{ year }}` which is not a valid year.  
Should I add an additional, `{# #}`-commented copyright banner with the current year to fix this?