### PR TITLE
Fix haskell template for tuple-like structs

### DIFF
--- a/tools/generator/templates/player/haskell/CApi.hsc.jinja2
+++ b/tools/generator/templates/player/haskell/CApi.hsc.jinja2
@@ -124,7 +124,7 @@ data {{ struct.str_name|capitalize }} = {{ struct.str_name|capitalize }} {
 
 {% if struct.str_tuple %}
 data C{{ struct.str_name|capitalize }} = C{{ struct.str_name|capitalize }}
-{% for name, type, comment in struct.str_field %} {{ type|haskell_type }}{% endfor %}
+{% for name, type, comment in struct.str_field %} C{{ type|haskell_type }}{% endfor %}
 {% else %}
 data C{{ struct.str_name|capitalize }} = C{{ struct.str_name|capitalize }} {
 {% for name, type, comment in struct.str_field %}


### PR DESCRIPTION
For any struct, the generator produces Haskell and C-compatible types (denoted with a leading `C`). Taking prologin2020's `position` struct as an example, we have `Position` and `CPosition`.

Position is defined as:
```haskell
data Position = Position
 Int Int
```
So the associated C-compatible type should be:
```haskell
data CPosition = CPosition
 CInt CInt
```

However the template wrongly generated:
```haskell
data CPosition = CPosition
 Int Int
```

This is made obvious when looking at the diff between the code generated for a non-tuple struct and a tuple struct:

```diff
186,190c186,187
< data Position = Position {
<   x :: Int, -- Coordonnée : x
<   y :: Int -- Coordonnée : y
< }
< 
---
> data Position = Position
>  Int Int
193,197c190,191
< data CPosition = CPosition {
<   cx :: CInt, -- Coordonnée : x
<   cy :: CInt -- Coordonnée : y
< }
< 
---
> data CPosition = CPosition
>  Int Int
```


Fixes #151.