### PR TITLE
Generator: minor Rust enhancements

### DIFF
--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -114,8 +114,6 @@ def rust_tuple_type(ctx, value: str, api_mod_path='') -> str:
 def rust_api_input_type(
     ctx, value: str, api_mod_path='', skip_ref=False
 ) -> str:
-    as_struct = ctx['game'].get_struct(value)
-
     if value == 'string':
         return '&str'
     elif is_array(value):
@@ -127,7 +125,7 @@ def rust_api_input_type(
                     ctx, get_array_inner(value), api_mod_path, True
                 )
             )
-    elif rust_is_copy(ctx, value) or is_tuple(as_struct):
+    elif rust_is_copy(ctx, value):
         return rust_api_output_type(ctx, value, api_mod_path)
     else:
         res = rust_api_output_type(ctx, value, api_mod_path)

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -31,7 +31,8 @@ pub enum {{ enum.enum_name|camel_case }} {
 }
 
 {% endfor %}
-{% for struct in game.struct if not struct is tuple %}
+{% for struct in game.struct %}
+{% if not struct is tuple %}
 #[derive({{ struct.str_name|rust_auto_traits|sort|join(', ') }})]
 pub struct {{ struct.str_name|camel_case }} {
     {% for field_name, field_type, field_comment in struct.str_field %}
@@ -39,6 +40,9 @@ pub struct {{ struct.str_name|camel_case }} {
     pub {{ field_name }}: {{ field_type|rust_api_output_type }},
     {% endfor %}
 }
+{% else %}
+pub type {{ struct.str_name|camel_case }} = {{ struct.str_name|rust_tuple_type }};
+{% endif %}
 
 {% endfor %}
 {%- for func in game.function %}

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -43,6 +43,10 @@ pub struct {{ struct.str_name|camel_case }} {
     {% endfor %}
 }
 {% else %}
+/// ### Fields
+{% for _, _, field_comment in struct.str_field %}
+/// - {{ field_comment }}
+{% endfor %}
 pub type {{ struct.str_name|camel_case }} = {{ struct.str_name|rust_tuple_type }};
 {% endif %}
 

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -26,7 +26,7 @@ pub const {{ constant.cst_name }}: {{ (constant.cst_type or 'int')|rust_api_outp
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum {{ enum.enum_name|camel_case }} {
     {% for field_name, field_comment in enum.enum_field %}
-    /// {{ field_comment }}
+    {{ field_comment|rust_comment(doc=True, indent=4)}}
     {{ field_name|camel_case }},
     {% endfor %}
 }
@@ -38,7 +38,7 @@ pub enum {{ enum.enum_name|camel_case }} {
 #[derive({{ struct.str_name|rust_auto_traits|sort|join(', ') }})]
 pub struct {{ struct.str_name|camel_case }} {
     {% for field_name, field_type, field_comment in struct.str_field %}
-    /// {{ field_comment }}
+    {{ field_comment|rust_comment(doc=True, indent=4) }}
     pub {{ field_name }}: {{ field_type|rust_api_output_type }},
     {% endfor %}
 }

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -17,11 +17,12 @@ use crate::ffi::{array_of_borrow_to_c, CToRust, RustToC};
 use std::{cell::UnsafeCell, borrow::Borrow};
 
 {% for constant in game.constant %}
-{{ constant.cst_comment|cxx_comment(doc=True) }}
+{{ constant.cst_comment|rust_comment(doc=True) }}
 pub const {{ constant.cst_name }}: {{ (constant.cst_type or 'int')|rust_api_output_type }} = {{ constant.cst_val }};
 
 {% endfor %}
 {% for enum in game.enum %}
+{{ enum.enum_summary|rust_comment(doc=True) }}
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum {{ enum.enum_name|camel_case }} {
     {% for field_name, field_comment in enum.enum_field %}
@@ -32,6 +33,7 @@ pub enum {{ enum.enum_name|camel_case }} {
 
 {% endfor %}
 {% for struct in game.struct %}
+{{ struct.str_summary|rust_comment(doc=True) }}
 {% if not struct is tuple %}
 #[derive({{ struct.str_name|rust_auto_traits|sort|join(', ') }})]
 pub struct {{ struct.str_name|camel_case }} {

--- a/tools/generator/test/languages/champion.rs
+++ b/tools/generator/test/languages/champion.rs
@@ -87,7 +87,7 @@ pub fn test() {
     };
     send_me_struct_with_struct(&s_with_struct);
 
-    send_me_tuple_with_struct((42, &simple, (42, true)));
+    send_me_tuple_with_struct(&(42, simple.clone(), (42, true)));
 
     let l = vec![
         StructWithArray {


### PR DESCRIPTION
- Use type aliases for tuples: for example, instead of using `(i32, i32)`, declare a type alias `type Position = (i32, i32)` and use it in the API. This makes the API more readable (functions take e.g. `pos: Position` instead of `pos: (i32, i32)`), and allows the type to have a rustdoc-generated documentation page where we can present the summary of the type and explanations for the fields.
- Document structs and enums: use the `summary` declared in the configuration to generate a doc-comment for structs and enums. This is already done in other languages, so not having them in Rust was probably an oversight;
- Code cleanups

:warning: This is a breaking change for tuples containing non-`Copy` fields. Say we have a `(String,)` tuple. Previously, we generated `(&String,)` in function arguments, but now we take the equivalent of `&(String,)`. This change however makes tuples more consistant with non-tuple structs