### PR TITLE
CI: do a full reinstall of PHP to avoid package conflicts

### DIFF
--- a/.github/workflows/stechec2-generator-test.yml
+++ b/.github/workflows/stechec2-generator-test.yml
@@ -25,16 +25,20 @@ jobs:
           ghc-version: '8.8.1'
 
       - name: Install language dependencies
+        # We need to purge the installed PHP tools to avoid conflicts
+        # when installing libphp-embed.
         # Some packages here are included in the --ldflags of php-config but
         # not present by default in the CI, so we install them manually.
         # (libargon2-1 and libsodium-dev)
         run: |
           sudo apt-get update
+          sudo apt-get purge php-common
           sudo apt-get install \
             python3 python3-dev python3-yaml python3-jinja2 python3-pytest \
             python3-pytest-cov flake8 \
             php-cli php-dev libphp-embed libargon2-0-dev libsodium-dev \
             ocaml mono-devel
+          sudo ln -s "/usr/lib/libphp$(php-config --version | grep -o '[0-9].[0-9]').so" /usr/lib/libphp.so
 
       - name: Test
         working-directory: ./tools


### PR DESCRIPTION
The pre-installed version of PHP in GitHub Actions is from [DEB.SURY.ORG](https://deb.sury.org/), but `libphp-embed` is not available there, so to me it looks like we need to uninstall PHP and reinstall it from the official APT repos.

Fixes the recent CI errors. Alternative to #163, cc @seirl