### PR TITLE
Fix C FFI type for arrays of tuples in Haskell

### DIFF
--- a/tools/generator/templates/player/haskell/CApi.hsc.jinja2
+++ b/tools/generator/templates/player/haskell/CApi.hsc.jinja2
@@ -124,7 +124,7 @@ data {{ struct.str_name|capitalize }} = {{ struct.str_name|capitalize }} {
 
 {% if struct.str_tuple %}
 data C{{ struct.str_name|capitalize }} = C{{ struct.str_name|capitalize }}
-{% for name, type, comment in struct.str_field %} C{{ type|haskell_type }}{% endfor %}
+{% for name, type, comment in struct.str_field %} C{{ type|haskell_c_type }}{% endfor %}
 {% else %}
 data C{{ struct.str_name|capitalize }} = C{{ struct.str_name|capitalize }} {
 {% for name, type, comment in struct.str_field %}


### PR DESCRIPTION
To handle transferring arrays to the C FFI, Haskell has a `CXXX_array` type for each used array type: https://github.com/prologin/stechec2/blob/49713208bd2ed3de9859c247736776544f483e9b/tools/generator/templates/player/haskell/CApi.hsc.jinja2#L194-L195
The `haskell_c_type` filter returns this type for arrays: https://github.com/prologin/stechec2/blob/49713208bd2ed3de9859c247736776544f483e9b/tools/generator/filters/haskell.py#L19-L23

However for tuples the templates used `haskell_type` instead, leading to invalid generated code like `C[XXX]`.