### PR TITLE
Allow/fix strings in constants

### DIFF
--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -137,6 +137,16 @@ def rust_api_input_type(
 
 
 @register_filter
+def rust_api_const_type(value: str) -> str:
+    const_types = {
+        'double': 'f64',
+        'int': 'i32',
+        'string': "&'static str",
+    }
+    return const_types[value]
+
+
+@register_filter
 @contextfilter
 def rust_is_copy(ctx, value: str) -> bool:
     """Check if a type implements the Copy trait"""

--- a/tools/generator/game.py
+++ b/tools/generator/game.py
@@ -71,6 +71,10 @@ class Game:
                     "Constant '{}' type '{}' does not match value '{}'"
                     .format(cst['cst_name'], cst['cst_type'], cst_type)
                 )
+            if cst['cst_type'] == 'string':
+                # Quotation marks are removed when YAML is parsed,
+                # add them back
+                cst['cst_val'] = '"{}"'.format(cst['cst_val'])
 
     def load_base_types(self):
         '''
@@ -376,7 +380,8 @@ GAME_SCHEMA = {
     'constant': [
         {
             'cst_name': CONSTANT,
-            'cst_val': Union(int, float),
+            'cst_val': Union(int, str, float),
+            'cst_type': O(re.compile('(int|string|double)')),
             'cst_comment': str,
         }
     ],

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -18,7 +18,7 @@ use std::{cell::UnsafeCell, borrow::Borrow};
 
 {% for constant in game.constant %}
 {{ constant.cst_comment|rust_comment(doc=True) }}
-pub const {{ constant.cst_name }}: {{ (constant.cst_type or 'int')|rust_api_output_type }} = {{ constant.cst_val }};
+pub const {{ constant.cst_name }}: {{ (constant.cst_type or 'int')|rust_api_const_type }} = {{ constant.cst_val }};
 
 {% endfor %}
 {% for enum in game.enum %}

--- a/tools/generator/test/games/test.yml
+++ b/tools/generator/test/games/test.yml
@@ -12,6 +12,10 @@ constant:
     cst_val: 42.42
     cst_type: double
     cst_comment: Floating point constant
+  -
+    cst_name: CONST_STR
+    cst_val: "TTY"
+    cst_comment: Value to use in simple_struct
 
 enum:
   -

--- a/tools/generator/test/languages/Champion.hs
+++ b/tools/generator/test/languages/Champion.hs
@@ -12,7 +12,7 @@ assert' :: Bool -> ()
 assert' False = error "Assertion failed."
 assert' _     = ()
 
-simpleStruct = Simple_struct 42 True 42.42 "TTY"
+simpleStruct = Simple_struct 42 True 42.42 const_str
 tupleStruct = Simple_tuple 42 True
 theStruct = Struct_with_array 42 (replicate 42 42) (replicate 42 simpleStruct) (replicate 42 tupleStruct)
 floatStruct = Struct_with_only_double 42.42 42.42

--- a/tools/generator/test/languages/Champion.java
+++ b/tools/generator/test/languages/Champion.java
@@ -70,7 +70,7 @@ public class Champion extends Api
         simple.field_i = 42;
         simple.field_bool = true;
         simple.field_double = 42.42;
-        simple.field_string = "TTY";
+        simple.field_string = CONST_STR;
         send_me_simple(simple);
 
         SimpleTuple tuple_struct = new SimpleTuple();
@@ -142,7 +142,7 @@ public class Champion extends Api
                 assert(l[i].field_str_arr[j].field_i == 42);
                 assert(l[i].field_str_arr[j].field_bool == true);
                 assert(l[i].field_str_arr[j].field_double == 42.42);
-                assert(l[i].field_str_arr[j].field_string.equals("TTY"));
+                assert(l[i].field_str_arr[j].field_string.equals(CONST_STR));
                 assert(l[i].field_tup_arr[j].field_0 == 42);
                 assert(l[i].field_tup_arr[j].field_1);
             }

--- a/tools/generator/test/languages/Champion.py
+++ b/tools/generator/test/languages/Champion.py
@@ -39,7 +39,7 @@ def test():
         field_i=42,
         field_bool=True,
         field_double=42.42,
-        field_string="TTY",
+        field_string=CONST_STR,
     )
     simple_tup = ((42, True))
 

--- a/tools/generator/test/languages/champion.c
+++ b/tools/generator/test/languages/champion.c
@@ -22,6 +22,7 @@ void test()
 {
     assert(CONST_VAL/4 == 10);
     assert(CONST_DOUBLE == 42.42);
+    assert(CONST_STR == "TTY");
 
     send_me_42(42);
     send_me_42_and_1337(42, 1337);
@@ -85,7 +86,7 @@ void test()
     simple.field_i = 42;
     simple.field_bool = true;
     simple.field_double = 42.42;
-    simple.field_string = "TTY";
+    simple.field_string = CONST_STR;
     send_me_simple(simple);
 
     simple_tuple tuple_struct;
@@ -167,7 +168,7 @@ void test()
             assert(ll.items[i].field_str_arr.items[j].field_i == 42);
             assert(ll.items[i].field_str_arr.items[j].field_bool == true);
             assert(ll.items[i].field_str_arr.items[j].field_double == 42.42);
-            assert(!strcmp(ll.items[i].field_str_arr.items[j].field_string, "TTY"));
+            assert(!strcmp(ll.items[i].field_str_arr.items[j].field_string, CONST_STR));
 
             assert(ll.items[i].field_tup_arr.items[j].field_0 == 42);
             assert(ll.items[i].field_tup_arr.items[j].field_1 == true);

--- a/tools/generator/test/languages/champion.cc
+++ b/tools/generator/test/languages/champion.cc
@@ -24,6 +24,7 @@ void test()
 {
     assert(CONST_VAL / 4 == 10);
     assert(CONST_DOUBLE == 42.42);
+    assert(CONST_STR == "TTY");
 
     send_me_42(42);
     send_me_42_and_1337(42, 1337);
@@ -75,7 +76,7 @@ void test()
     simple.field_i = 42;
     simple.field_bool = true;
     simple.field_double = 42.42;
-    simple.field_string = "TTY";
+    simple.field_string = CONST_STR;
     send_me_simple(simple);
 
     simple_tuple tuple_struct;
@@ -139,7 +140,7 @@ void test()
             assert(l[i].field_str_arr[j].field_i == 42);
             assert(l[i].field_str_arr[j].field_bool == true);
             assert(l[i].field_str_arr[j].field_double == 42.42);
-            assert(l[i].field_str_arr[j].field_string == "TTY");
+            assert(l[i].field_str_arr[j].field_string == CONST_STR);
             assert(l[i].field_tup_arr[j].field_0 == 42);
             assert(l[i].field_tup_arr[j].field_1);
         }

--- a/tools/generator/test/languages/champion.cs
+++ b/tools/generator/test/languages/champion.cs
@@ -81,7 +81,7 @@ namespace Champion {
       simple.FieldI = 42;
       simple.FieldBool = true;
       simple.FieldDouble = 42.42;
-      simple.FieldString = "TTY";
+      simple.FieldString = Api.CONST_STR;
       Api.SendMeSimple(simple);
 
       SimpleTuple tuple_struct = new SimpleTuple();
@@ -154,7 +154,7 @@ namespace Champion {
           Assert(l[i].FieldStrArr[j].FieldI == 42);
           Assert(l[i].FieldStrArr[j].FieldBool == true);
           Assert(l[i].FieldStrArr[j].FieldDouble == 42.42);
-          Assert(l[i].FieldStrArr[j].FieldString == "TTY");
+          Assert(l[i].FieldStrArr[j].FieldString == Api.CONST_STR);
           Assert(l[i].FieldTupArr[j].Field0 == 42);
           Assert(l[i].FieldTupArr[j].Field1);
         }

--- a/tools/generator/test/languages/champion.ml
+++ b/tools/generator/test/languages/champion.ml
@@ -45,7 +45,7 @@ let test () =  (* Pose ton code ici *)
     let simple = { field_i = 42;
                    field_bool = true;
                    field_double = 42.42;
-                   field_string = "TTY" } in
+                   field_string = const_str } in
     send_me_simple simple;
     send_me_42s { field_int = 42;
                   field_int_arr = times42 42;

--- a/tools/generator/test/languages/champion.php
+++ b/tools/generator/test/languages/champion.php
@@ -48,7 +48,7 @@ function test()
         "field_i" => 42,
         "field_bool" => true,
         "field_double" => 42.42,
-        "field_string" => "TTY",
+        "field_string" => CONST_STR,
     );
     $tuple1 = array(
         "field_0" => 42,

--- a/tools/generator/test/languages/champion.rs
+++ b/tools/generator/test/languages/champion.rs
@@ -8,8 +8,9 @@ pub fn test_alert() {
 
 /// Called 10K times to test if things work well.
 pub fn test() {
-    assert!(CONST_VAL / 4 == 10);
-    assert!(CONST_DOUBLE == 42.42);
+    assert_eq!(CONST_VAL / 4, 10);
+    assert_eq!(CONST_DOUBLE, 42.42);
+    assert_eq!(CONST_STR, "TTY");
 
     send_me_42(42);
     send_me_42_and_1337(42, 1337);
@@ -56,7 +57,7 @@ pub fn test() {
         field_i: 42,
         field_bool: true,
         field_double: 42.42,
-        field_string: String::from("TTY"),
+        field_string: String::from(CONST_STR),
     };
     send_me_simple(&simple);
 


### PR DESCRIPTION
Currently the YAML schema enforces that constants can't be strings, but `load_constants` has code to handle string values. This fixes the inconsistency by allowing strings to be used in constants.