### PR TITLE
generator: jinja 3.1 support

### DIFF
--- a/tools/generator/filters/c.py
+++ b/tools/generator/filters/c.py
@@ -1,5 +1,8 @@
 from functools import partial
-from jinja2 import contextfilter
+try:
+    from jinja2 import pass_context
+except ImportError:  # jinja < 3
+    from jinja2 import contextfilter as pass_context
 
 from . import register_filter
 from .common import generic_args, generic_prototype, is_array, get_array_inner
@@ -37,7 +40,7 @@ c_comment = register_filter(cxx_comment, name='c_comment')
 
 # To avoid name clashing, we prefix the internal C++ structs
 @register_filter
-@contextfilter
+@pass_context
 def c_internal_cxx_type(ctx, value: str) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -48,7 +51,7 @@ def c_internal_cxx_type(ctx, value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def c_to_cxx(ctx, value: str) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -64,7 +67,7 @@ def c_to_cxx(ctx, value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cxx_to_c(ctx, value: str) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -80,7 +83,7 @@ def cxx_to_c(ctx, value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def c_internal_cxx_prototype(ctx, *args, **kwargs) -> str:
     return generic_prototype(type_mapper=partial(c_internal_cxx_type, ctx),
                              *args, **kwargs)

--- a/tools/generator/filters/cs.py
+++ b/tools/generator/filters/cs.py
@@ -1,5 +1,10 @@
 from functools import partial
-from jinja2 import contextfilter, contextfunction
+try:
+    from jinja2 import pass_context
+    contextfunction = pass_context
+except ImportError:  # jinja < 3
+    from jinja2 import contextfilter as pass_context
+    from jinja2 import contextfunction
 
 from . import register_filter, register_function
 from .common import (generic_comment, get_array_inner, generic_prototype,
@@ -8,7 +13,7 @@ from .cxx import cxx_type
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cs_type(ctx, value) -> str:
     if is_array(value):
         return '{}[]'.format(cs_type(ctx, get_array_inner(value)))
@@ -24,7 +29,7 @@ cs_comment = register_filter(
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cs_prototype(ctx, value, *args, **kwargs) -> str:
     value = value.copy()
     value['fct_name'] = camel_case(value['fct_name'])
@@ -41,7 +46,7 @@ def cs_is_reftype(ctx, value: str) -> bool:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cs_mono_type(ctx, value):
     if is_array(value):
         return 'MonoArray*'
@@ -60,14 +65,14 @@ def cs_mono_type(ctx, value):
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cs_mono_prototype(ctx, *args, **kwargs) -> str:
     return generic_prototype(type_mapper=partial(cs_mono_type, ctx),
                              *args, prefix='cs_', **kwargs)
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cs_to_cxx(ctx, value: str) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -81,7 +86,7 @@ def cs_to_cxx(ctx, value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cxx_to_cs(ctx, value: str) -> str:
     if is_array(value):
         base_type = get_array_inner(value)

--- a/tools/generator/filters/haskell.py
+++ b/tools/generator/filters/haskell.py
@@ -1,5 +1,8 @@
 from functools import partial
-from jinja2 import contextfilter
+try:
+    from jinja2 import pass_context
+except ImportError:  # jinja < 3
+    from jinja2 import contextfilter as pass_context
 
 from . import register_filter
 from .c import c_type, c_args, c_internal_cxx_type
@@ -24,7 +27,7 @@ def haskell_c_type(type_id: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cptr_type(ctx, type_id: str) -> str:
     res = c_type(type_id)
     if is_array(type_id) or ctx['game'].get_struct(type_id):
@@ -62,7 +65,7 @@ def haskell_get_array_types(game: dict):
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cptr_to_cxx(ctx, value: str, use_ptr: bool = False) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -79,7 +82,7 @@ def cptr_to_cxx(ctx, value: str, use_ptr: bool = False) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cxx_to_cptr(ctx, value: str, use_ptr: bool = False) -> str:
     if is_array(value):
         base_type = get_array_inner(value)
@@ -96,14 +99,14 @@ def cxx_to_cptr(ctx, value: str, use_ptr: bool = False) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def cptr_internal_cxx_prototype(ctx, *args, **kwargs) -> str:
     return generic_prototype(type_mapper=partial(c_internal_cxx_type, ctx),
                              *args, **kwargs)
 
 
 @register_filter
-@contextfilter
+@pass_context
 def haskell_c_prototype(ctx, *args, **kwargs) -> str:
     type_mapper = partial(cptr_type, ctx)
     arg_mapper = partial(c_args, type_mapper=type_mapper)

--- a/tools/generator/filters/python.py
+++ b/tools/generator/filters/python.py
@@ -1,5 +1,8 @@
 from functools import partial
-from jinja2 import contextfilter
+try:
+    from jinja2 import pass_context
+except ImportError:  # jinja < 3
+    from jinja2 import contextfilter as pass_context
 
 from . import register_filter
 from .common import generic_comment, get_array_inner, is_array, is_tuple
@@ -7,7 +10,7 @@ from .cxx import cxx_type
 
 
 @register_filter
-@contextfilter
+@pass_context
 def python_type(ctx, val: str) -> str:
     base_types = {
         'void': 'None',

--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -1,4 +1,7 @@
-from jinja2 import contextfilter
+try:
+    from jinja2 import pass_context
+except ImportError:  # jinja < 3
+    from jinja2 import contextfilter as pass_context
 
 from . import register_filter
 from .common import (
@@ -11,7 +14,7 @@ register_filter(cxx_comment, name='rust_comment')
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_ffi_call(ctx, func) -> str:
     """
     Call FFI function, assuming that non-copy types are wrapped in a
@@ -32,7 +35,7 @@ def rust_ffi_call(ctx, func) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_prototype(ctx, func, ffi=False) -> str:
     # Input params
     get_type = rust_ffi_type if ffi else rust_api_input_type
@@ -57,7 +60,7 @@ def rust_prototype(ctx, func, ffi=False) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_ffi_type(ctx, value: str) -> str:
     """Type sent to the FFI"""
     basic_types = {
@@ -77,7 +80,7 @@ def rust_ffi_type(ctx, value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_api_output_type(ctx, value: str, api_mod_path='') -> str:
     basic_types = {
         'bool': 'bool',
@@ -98,7 +101,7 @@ def rust_api_output_type(ctx, value: str, api_mod_path='') -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_tuple_type(ctx, value: str, api_mod_path='') -> str:
     tup = ctx['game'].get_struct(value)
     assert is_tuple(tup), "{} is not a tuple struct".format(value)
@@ -110,7 +113,7 @@ def rust_tuple_type(ctx, value: str, api_mod_path='') -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_api_input_type(
     ctx, value: str, api_mod_path='', skip_ref=False
 ) -> str:
@@ -147,7 +150,7 @@ def rust_api_const_type(value: str) -> str:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_is_copy(ctx, value: str) -> bool:
     """Check if a type implements the Copy trait"""
     as_struct = ctx['game'].get_struct(value)
@@ -165,7 +168,7 @@ def rust_is_copy(ctx, value: str) -> bool:
 
 
 @register_filter
-@contextfilter
+@pass_context
 def rust_auto_traits(ctx, value: str) -> set:
     """
     Return the list of auto traits that can be implemented for given input


### PR DESCRIPTION
jinja 3.0 deprecated `contextfilter`, 3.1 removed it.

This PR uses the new name, while keeping compatibility for jinja < 3.

Tested with jinja 3.1.2 and 2.11.3