### PR TITLE
generator/python: add docstrings and type hints

### DIFF
--- a/tools/generator/filters/python.py
+++ b/tools/generator/filters/python.py
@@ -11,7 +11,7 @@ from .cxx import cxx_type
 
 @register_filter
 @pass_context
-def python_type(ctx, val: str) -> str:
+def python_type(ctx, val: str, tuple_alias: bool = True) -> str:
     base_types = {
         'void': 'None',
         'int': 'int',
@@ -21,20 +21,35 @@ def python_type(ctx, val: str) -> str:
     if val in base_types:
         return base_types[val]
     if is_array(val):
-        return 'List[{}]'.format(python_type(ctx, get_array_inner(val)))
+        return 'List[{}]'.format(
+            python_type(ctx, get_array_inner(val), tuple_alias)
+        )
     s = ctx['game'].get_struct(val)
-    if s and is_tuple(s):
-        return 'Tuple[{}]'.format(', '.join(
-            python_type(ctx, arg_type) for _, arg_type, _ in s['str_field']
-        ))
+    if s and is_tuple(s) and tuple_alias:
+        return 'Tuple[{}]'.format(
+            ', '.join(
+                python_type(ctx, arg_type, tuple_alias)
+                for _, arg_type, _ in s['str_field']
+            )
+        )
     return val
 
 
 @register_filter
-def python_prototype(func) -> str:
+@pass_context
+def python_prototype(ctx, func, typed: bool = False) -> str:
+    args_and_types = [
+        (arg_name, python_type(ctx, arg_type, False))
+        for arg_name, arg_type, _ in func['fct_arg']
+    ]
+    if typed:
+        return 'def {}({}) -> {}:'.format(
+            func['fct_name'],
+            ', '.join(f'{i}: {j}' for i, j in args_and_types),
+            python_type(ctx, func['fct_ret_type'], False),
+        )
     return 'def {}({}):'.format(
-        func['fct_name'],
-        ', '.join(arg_name for arg_name, _, _ in func['fct_arg'])
+        func['fct_name'], ', '.join(i for i, _ in args_and_types)
     )
 
 
@@ -42,6 +57,12 @@ python_comment = register_filter(
     partial(generic_comment, start='# '),
     name='python_comment',
 )
+
+
+@register_filter
+def python_docstring(value: str, indent: int = 0) -> str:
+    ind = ' ' * indent
+    return '"""\n' + generic_comment(value, ind) + '\n' + ind + '"""'
 
 
 @register_filter
@@ -60,3 +81,30 @@ def python_to_cxx(value: str) -> str:
         )
     else:
         return 'python_to_cxx<PyObject*, {}>'.format(cxx_type(value))
+
+
+@register_filter
+def get_python_import(functions) -> str:
+    """Get all needed imports to be able to declare some functions"""
+
+    all_types = set()
+    for func in functions:
+        for _, arg_type, _ in func['fct_arg']:
+            all_types.add(arg_type)
+        all_types.add(func['fct_ret_type'])
+    import_api = set()
+    import_typing = set()
+    for val in all_types:
+        while is_array(val):
+            import_typing.add('List')
+            val = get_array_inner(val)
+        if val not in ('void', 'int', 'double', 'string', 'bool'):
+            import_api.add(val)
+    ret = ''
+    if import_typing:
+        ret += f'from typing import {", ".join(sorted(import_typing))}'
+    if import_typing and import_api:
+        ret += "\n\n"
+    if import_api:
+        ret += f'from api import {", ".join(sorted(import_api))}'
+    return ret

--- a/tools/generator/player.py
+++ b/tools/generator/player.py
@@ -37,7 +37,7 @@ LANGUAGES = {
         'symlinks': ['api.php', 'interface.cc', 'Makefile-php']},
     'python': {
         'files': ['Champion.py', 'Makefile'],
-        'symlinks': ['api.py', 'interface.cc', 'Makefile-python']},
+        'symlinks': ['_api.pyi', 'api.py', 'interface.cc', 'Makefile-python']},
     'rust': {
         'files': ['Makefile', 'champion.rs'],
         'symlinks': ['Cargo.toml', 'Makefile-rust', 'api.rs', 'ffi.rs',

--- a/tools/generator/templates/player/python/_api.pyi.jinja2
+++ b/tools/generator/templates/player/python/_api.pyi.jinja2
@@ -1,0 +1,12 @@
+{# SPDX-License-Identifier: GPL-2.0-or-later #}
+{# Copyright (c) 2022 Association Prologin <association@prologin.org> -#}
+{# Copyright (c) 2022 Sacha Delanoue -#}
+# {{ stechec2_generated }}
+
+{{ game.function|get_python_import }}
+{% for func in game.function %}
+
+{{ func|python_prototype(typed=True) }}
+    {{ func.fct_summary|python_docstring(4) }}
+    ...
+{% endfor %}

--- a/tools/generator/templates/player/python/api.py.jinja2
+++ b/tools/generator/templates/player/python/api.py.jinja2
@@ -17,23 +17,32 @@ from _api import *
 
 {# Enums #}
 {% for enum in game.enum %}
-{{ enum.enum_summary|python_comment }}
 class {{ enum.enum_name }}(IntEnum):
-    {% for field_name, field_comment in enum.enum_field %}
-    {{ field_name|upper }} = {{ loop.index0 }}  # <- {{ field_comment }}
-    {% endfor %}
+    {{ enum.enum_summary|python_docstring(4) }}
 
+    {% for field_name, field_comment in enum.enum_field %}
+    {{ field_name|upper }} = {{ loop.index0 }}
+    """{{ field_comment }}"""
+
+    {% endfor %}
 
 {% endfor %}
 {# Structs #}
 {% for struct in game.struct %}
-    {% if not struct.str_tuple %}
+    {% if struct.str_tuple %}
 {{ struct.str_summary|python_comment }}
-class {{ struct.str_name }}(NamedTuple):
-    {% for field_name, field_type, field_comment in struct.str_field %}
-    {{ field_name }}: {{ field_type|python_type }}  # {{ field_comment }}
-    {% endfor %}
+{{ struct.str_name }} = {{ struct.str_name|python_type }}
 
+
+    {% else %}
+class {{ struct.str_name }}(NamedTuple):
+    {{ struct.str_summary|python_docstring(4) }}
+
+    {% for field_name, field_type, field_comment in struct.str_field %}
+    {{ field_name }}: {{ field_type|python_type }}
+    """{{ field_comment }}"""
+
+    {% endfor %}
 
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
Generates the .pyi file for the API functions. They come with type hints and docstring.

I also changed the comments describing enums and structs into docstrings so that IDE can see them.

Fixes #173