### PR TITLE
MVP support for idiomatic errors

### DIFF
--- a/doc/rules.rst
+++ b/doc/rules.rst
@@ -145,6 +145,10 @@ An enumeration is described by three fields:
 
 * ``enum_name``: the name of the enum.
 * ``enum_summary``: a short documentation of the enum.
+* ``enum_error`` (yes/no): if set to "yes", the enum will be interpreted as
+  an error and enable some sugar in the languages that support it. The first
+  variant of the enum will represent success and all other variants represent
+  errors.
 * ``enum_field``: a list of the different fields of the enum. Each field is a
   list containing:
 
@@ -162,6 +166,7 @@ We can write it quickly::
       enum_summary:
         "Enumeration containing all possible error types that can be returned
         by action functions"
+      enum_error: yes
       enum_field:
         - [ok, "no error occurred"]
         - [out_of_bounds, "provided position is out of bounds"]

--- a/games/plusminus/champions/cxx/prologin.hh
+++ b/games/plusminus/champions/cxx/prologin.hh
@@ -15,7 +15,7 @@
 typedef enum error
 {
     OK,           /* <- no error occurred */
-    OUT_OF_BOUDS, /* <- guess is out of bounds */
+    OUT_OF_BOUNDS, /* <- guess is out of bounds */
 } error;
 // This is needed for old compilers
 namespace std

--- a/tools/generator/filters/common.py
+++ b/tools/generator/filters/common.py
@@ -30,6 +30,11 @@ def is_tuple(struct) -> bool:
     return struct.get('str_tuple', False)
 
 
+@register_test
+def is_error(enum) -> bool:
+    return enum.get('enum_error', False)
+
+
 @register_filter
 def generic_args(value, type_mapper=lambda x: x) -> str:
     return ", ".join("{} {}".format(type_mapper(type_), name)
@@ -56,3 +61,12 @@ def generic_comment(value: str, start: str, indent: int = 0) -> str:
         break_long_words=False,
         replace_whitespace=False
     ))
+
+
+@register_filter
+def enum_fields_except_ok(enum):
+    """Returns the list of variants for an enum,
+    except the OK variant of an error."""
+    if is_error(enum):
+        return enum['enum_field'][1:]
+    return enum['enum_field']

--- a/tools/generator/filters/haskell.py
+++ b/tools/generator/filters/haskell.py
@@ -7,15 +7,22 @@ except ImportError:  # jinja < 3
 from . import register_filter
 from .c import c_type, c_args, c_internal_cxx_type
 from .common import (generic_comment, generic_prototype, get_array_inner,
-                     is_array)
+                     is_array, is_error)
 
 
 @register_filter
-def haskell_type(type_id: str) -> str:
+@pass_context
+def haskell_type(ctx, type_id: str, *, parens: bool = False) -> str:
     if is_array(type_id):
-        return f'[{haskell_type(get_array_inner(type_id))}]'
+        return f'[{haskell_type(ctx, get_array_inner(type_id))}]'
     elif type_id == 'void':
         return '()'
+    enum = ctx['game'].get_enum(type_id)
+    if enum and is_error(enum):
+        ty = 'Either () {}'.format(type_id.capitalize())
+        if parens:
+            ty = '({})'.format(ty)
+        return ty
     return type_id.capitalize()
 
 

--- a/tools/generator/filters/rust.py
+++ b/tools/generator/filters/rust.py
@@ -5,7 +5,7 @@ except ImportError:  # jinja < 3
 
 from . import register_filter
 from .common import (
-    camel_case, get_array_inner, is_array, is_returning, is_tuple,
+    camel_case, get_array_inner, is_array, is_error, is_returning, is_tuple,
 )
 from .cxx import cxx_comment
 
@@ -94,6 +94,9 @@ def rust_api_output_type(ctx, value: str, api_mod_path='') -> str:
         return 'Vec<{}>'.format(
             rust_api_output_type(ctx, get_array_inner(value), api_mod_path)
         )
+    enum = ctx['game'].get_enum(value)
+    if enum and is_error(enum):
+        return 'Result<(), {}>'.format(api_mod_path + camel_case(value))
     elif value in basic_types:
         return basic_types[value]
     else:

--- a/tools/generator/game.py
+++ b/tools/generator/game.py
@@ -152,6 +152,7 @@ class Game:
         '''Perform various integrity checks on the game objects'''
         self.check_name_unicity()
         self.check_reserved_keywords()
+        self.check_empty_errors()
 
     def check_name_unicity(self):
         '''
@@ -230,6 +231,15 @@ class Game:
             for arg_name, _, _ in func['fct_arg']:
                 throw_if_conflicts(
                     arg_name, "Function {}: argument".format(func['fct_name']))
+
+    def check_empty_errors(self):
+        '''Make sure errors have at least one field'''
+        for enum in self.game['enum']:
+            if enum.get('enum_error', False) and enum['enum_field'] == []:
+                raise GameError(
+                    "Enum '{}' is an error but has no fields."
+                    .format(enum['enum_name'])
+                )
 
     def get_enum(self, enum_name):
         '''Get an enum by name, None if it does not exist'''
@@ -378,6 +388,7 @@ GAME_SCHEMA = {
         {
             'enum_name': IDENTIFIER,
             'enum_summary': str,
+            'enum_error': O(bool),
             'enum_field': [(IDENTIFIER, str)],
         }
     ],

--- a/tools/generator/templates/player/caml/api.ml.jinja2
+++ b/tools/generator/templates/player/caml/api.ml.jinja2
@@ -9,7 +9,7 @@ let {{ constant.cst_name|lower }} = {{ constant.cst_val }}
 {% for enum in game.enum %}
 {{ enum.enum_summary|caml_comment(doc=True) }}
 type {{ enum.enum_name }} =
-  {% for field_name, field_comment in enum.enum_field %}
+  {% for field_name, field_comment in enum|enum_fields_except_ok %}
   | {{ field_name|capitalize }} (** <- {{ field_comment }} *)
   {% endfor %}
 

--- a/tools/generator/templates/player/caml/interface.cc.jinja2
+++ b/tools/generator/templates/player/caml/interface.cc.jinja2
@@ -160,6 +160,36 @@ std::vector<double> caml_to_cxx_array(value in)
 
 {% for enum in game.enum %}
 
+{% if enum is error %}
+template<>
+value cxx_to_caml<value, {{ enum.enum_name }}>({{ enum.enum_name }} in)
+{
+    CAMLparam0();
+    CAMLlocal1(result);
+
+    if (in == {{ enum.enum_field[0][0]|upper }}) {
+        result = caml_alloc_small(1, 0);
+        Field(result, 0) = Val_unit;
+    } else {
+        result = caml_alloc_small(1, 1);
+        Field(result, 0) = Val_int(in - 1);
+    }
+
+    CAMLreturn(result);
+}
+
+template<>
+{{ enum.enum_name }} caml_to_cxx<value, {{ enum.enum_name }}>(value in)
+{
+    CAMLparam1(in);
+
+    if (Tag_val(in) == 0) {
+        CAMLreturnT({{ enum.enum_name }}, {{ enum.enum_field[0][0]|upper }});
+    } else {
+        CAMLreturnT({{ enum.enum_name }}, ({{ enum.enum_name }})(Int_val(in) + 1));
+    }
+}
+{% else %}
 {{ enum.enum_summary|cxx_comment }}
 template<>
 value cxx_to_caml<value, {{ enum.enum_name }}>({{ enum.enum_name }} in)
@@ -174,6 +204,7 @@ template<>
     CAMLparam1(in);
     CAMLreturnT({{ enum.enum_name }}, ({{ enum.enum_name }})Int_val(in));
 }
+{% endif %}
 {% endfor %}
 {% for struct in game.struct %}
 

--- a/tools/generator/templates/player/haskell/CApi.hsc.jinja2
+++ b/tools/generator/templates/player/haskell/CApi.hsc.jinja2
@@ -87,12 +87,27 @@ instance ApiStorable String where
 
 {{ enum.enum_summary|haskell_comment }}
 data {{ enum.enum_name|capitalize }} =
-{% for field_name, field_comment in enum.enum_field %}
+{% for field_name, field_comment in enum|enum_fields_except_ok %}
 {% if not loop.first %}  |{% else %}   {% endif %} {{ field_name|capitalize }} {{ field_comment|haskell_comment }}
 {% endfor %}
   deriving(Show, Eq, Enum)
 type C{{ enum.enum_name|capitalize }} = CInt
 
+{% if enum is error %}
+instance ApiStorable (Either () {{ enum.enum_name|capitalize }}) where
+  type ApiStorableType (Either () {{ enum.enum_name|capitalize }}) = CInt
+  toStorable (Left ()) f = f $ fromIntegral 0
+  toStorable (Right x) f = f $ fromIntegral $ fromEnum x + 1
+  {-# INLINE toStorable #-}
+  unStorable 0 = return $ Left ()
+  unStorable x = return $ Right $ toEnum $ fromIntegral x - 1
+  {-# INLINE unStorable #-}
+  type ApiStorableBaseType (Either () {{ enum.enum_name|capitalize }}) = ApiStorableType (Either () {{ enum.enum_name|capitalize }})
+  toStorableBase = toStorable
+  {-# INLINE toStorableBase #-}
+  unStorableBase = unStorable
+  {-# INLINE unStorableBase #-}
+{% else %}
 instance ApiStorable {{ enum.enum_name|capitalize }} where
   type ApiStorableType {{ enum.enum_name|capitalize }} = CInt
   toStorable x f = f (fromIntegral (fromEnum x))
@@ -104,6 +119,7 @@ instance ApiStorable {{ enum.enum_name|capitalize }} where
   {-# INLINE toStorableBase #-}
   unStorableBase = unStorable
   {-# INLINE unStorableBase #-}
+{% endif %}
 
 {% endfor %}
 
@@ -243,10 +259,11 @@ instance ApiStorable {{ type|haskell_type }} where
 
 {% for func in game.function %}
 {{ func.fct_summary|haskell_comment }}
-{{ func.fct_name }} ::{% for _, type, _ in func.fct_arg %} {{ type|haskell_type }} -> {% endfor %}IO {{ func.fct_ret_type|haskell_type }}
+{{ func.fct_name }} ::{% for _, type, _ in func.fct_arg %} {{ type|haskell_type }} -> {% endfor %}IO {{ func.fct_ret_type|haskell_type(parens=True) }}
 {{ func.fct_name }}{% for name, _, _ in func.fct_arg %} {{ name }} {% endfor %} ={% for name, _, _ in func.fct_arg %} toStorable {{ name }} $ \{{ name }}' -> {% endfor %} (hs_{{ func.fct_name }} {% for name, _, _ in func.fct_arg %} {{ name }}'{% endfor %}) >>= unStorable
 
-
 foreign import ccall
-  hs_{{ func.fct_name }} :: {% for _, type, _ in func.fct_arg %} (ApiStorableType {{ type|haskell_type }}) ->{% endfor %} IO (ApiStorableType {{ func.fct_ret_type|haskell_type }})
+  hs_{{ func.fct_name }} :: {% for _, type, _ in func.fct_arg %} (ApiStorableType {{ type|haskell_type(parens=True) }}) ->{% endfor %} IO (ApiStorableType {{ func.fct_ret_type|haskell_type(parens=True) }})
+
+
 {% endfor %}

--- a/tools/generator/templates/player/rust/api.rs.jinja2
+++ b/tools/generator/templates/player/rust/api.rs.jinja2
@@ -25,7 +25,7 @@ pub const {{ constant.cst_name }}: {{ (constant.cst_type or 'int')|rust_api_cons
 {{ enum.enum_summary|rust_comment(doc=True) }}
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum {{ enum.enum_name|camel_case }} {
-    {% for field_name, field_comment in enum.enum_field %}
+    {% for field_name, field_comment in enum|enum_fields_except_ok %}
     {{ field_comment|rust_comment(doc=True, indent=4)}}
     {{ field_name|camel_case }},
     {% endfor %}

--- a/tools/generator/templates/player/rust/ffi.rs.jinja2
+++ b/tools/generator/templates/player/rust/ffi.rs.jinja2
@@ -193,6 +193,40 @@ where
 {% with name=enum.enum_name|camel_case %}
 // Conversions for {{ enum.enum_name }}
 
+{% if enum is error %}
+impl CToRust<Result<(), api::{{ name }}>> for {{ name }} {
+    unsafe fn to_rust(self) -> Result<(), api::{{ name }}> {
+        match self {
+            {{ name }}::{{ enum.enum_field[0][0]|camel_case }} => Ok(()),
+            {% for field_name, _ in enum.enum_field[1:] %}
+            {{ name }}::{{ field_name|camel_case }} => Err(api::{{ name }}::{{ field_name|camel_case }}),
+            {% endfor %}
+        }
+    }
+}
+
+impl RustToC<{{ name }}> for Result<(), api::{{ name }}> {
+    unsafe fn to_c(&self) -> {{ name }} {
+        match self {
+            Ok(()) => {{ name }}::{{ enum.enum_field[0][0]|camel_case }},
+            {% for field_name, _ in enum.enum_field[1:] %}
+            Err(api::{{ name }}::{{ field_name|camel_case }}) => {{ name }}::{{ field_name|camel_case }},
+            {% endfor %}
+        }
+    }
+}
+
+impl RustToC<{{ name }}> for api::{{ name }} {
+    unsafe fn to_c(&self) -> {{ name }} {
+        match self {
+            {% for field_name, _ in enum|enum_fields_except_ok %}
+            api::{{ name }}::{{ field_name|camel_case }} => {{ name }}::{{ field_name|camel_case }},
+            {% endfor %}
+        }
+    }
+}
+
+{% else %}
 impl CToRust<api::{{ name }}> for {{ name }} {
     unsafe fn to_rust(self) -> api::{{ name }} {
         match self {
@@ -213,6 +247,7 @@ impl RustToC<{{ name }}> for api::{{ name }} {
     }
 }
 
+{% endif %}
 {% endwith %}
 {% endfor -%}
 

--- a/tools/generator/test/games/test.yml
+++ b/tools/generator/test/games/test.yml
@@ -25,6 +25,14 @@ enum:
     enum_field:
       - [val1, "value 1"]
       - [val2, "value 2"]
+  -
+    enum_name: test_error
+    enum_summary:
+      "Just a simple error."
+    enum_error: yes
+    enum_field:
+      - [ok, "ok!"]
+      - [non_zero, "How dare you"]
 
 struct:
   -
@@ -250,6 +258,12 @@ function:
     fct_ret_type: void
     fct_arg:
       - [s, tuple_with_struct, the tuple]
+  -
+    fct_name: simple_fallible
+    fct_summary: Don't pass a non-zero value
+    fct_ret_type: test_error
+    fct_arg:
+      - [i, int, Should be perfectly balanced]
 
 user_function:
   -

--- a/tools/generator/test/languages/Champion.hs
+++ b/tools/generator/test/languages/Champion.hs
@@ -70,6 +70,9 @@ test = do
 
   send_me_tuple_with_array $ Tuple_with_array 42 (replicate 42 tupleStruct)
 
+  () <- assert' . (== Left ()) <$> simple_fallible 0
+  () <- assert' . (== Right Non_zero) <$> simple_fallible 42
+
   return ()
 
 

--- a/tools/generator/test/languages/Champion.java
+++ b/tools/generator/test/languages/Champion.java
@@ -161,6 +161,9 @@ public class Champion extends Api
         }
         send_me_tuple_with_array(t_with_array);
 
+        assert(simple_fallible(0) == TestError.OK);
+        assert(simple_fallible(42) == TestError.NON_ZERO);
+
         // Specific Java test
         StructWithStruct sws = new StructWithStruct();
         assert(sws.field_struct != null);

--- a/tools/generator/test/languages/Champion.py
+++ b/tools/generator/test/languages/Champion.py
@@ -82,3 +82,6 @@ def test():
         field_tup_arr=[(42, True)] * 42)] * 42
 
     send_me_tuple_with_array((42, [(42, True)] * 42))
+
+    assert simple_fallible(0) == test_error.OK
+    assert simple_fallible(42) == test_error.NON_ZERO

--- a/tools/generator/test/languages/champion.c
+++ b/tools/generator/test/languages/champion.c
@@ -192,5 +192,8 @@ void test()
     }
     send_me_tuple_with_array(t_with_array);
     free(t_with_array.field_1_array.items);
+
+    assert(simple_fallible(0) == OK);
+    assert(simple_fallible(42) == NON_ZERO);
 }
 

--- a/tools/generator/test/languages/champion.cc
+++ b/tools/generator/test/languages/champion.cc
@@ -167,4 +167,7 @@ void test()
         t_with_array.field_1_array.push_back(tuple_struct);
     }
     send_me_tuple_with_array(t_with_array);
+
+    assert(simple_fallible(0) == OK);
+    assert(simple_fallible(42) == NON_ZERO);
 }

--- a/tools/generator/test/languages/champion.cs
+++ b/tools/generator/test/languages/champion.cs
@@ -172,6 +172,9 @@ namespace Champion {
         t_with_array.Field1Array[i] = tuple_struct;
       }
       Api.SendMeTupleWithArray(t_with_array);
+
+      Assert(Api.SimpleFallible(0) == TestError.OK);
+      Assert(Api.SimpleFallible(42) == TestError.NON_ZERO);
     }
   }
 }

--- a/tools/generator/test/languages/champion.ml
+++ b/tools/generator/test/languages/champion.ml
@@ -70,6 +70,10 @@ let test () =  (* Pose ton code ici *)
                            field_str_arr = times42 simple;
                            field_tup_arr = times42 (42, true) }));
     send_me_tuple_with_array (42, times42 (42, true));
+
+    assert (simple_fallible 0 = Ok ());
+    assert (simple_fallible 42 = Error Non_zero);
+
     flush stderr; flush stdout (* Pour que vos sorties s'affichent *)
   end
 

--- a/tools/generator/test/languages/champion.php
+++ b/tools/generator/test/languages/champion.php
@@ -100,4 +100,7 @@ function test()
         "field_0_count" => 42,
         "field_1_array" => array_fill(0, 42, $tuple1)
     ));
+
+    assert(simple_fallible(0) == OK);
+    assert(simple_fallible(42) == NON_ZERO);
 }

--- a/tools/generator/test/languages/champion.rs
+++ b/tools/generator/test/languages/champion.rs
@@ -104,5 +104,8 @@ pub fn test() {
     let lr = send_me_struct_array(&l_with_refs);
     assert_eq!(l, lr);
 
-    send_me_tuple_with_array(&(42, vec![(42, true); 42]))
+    send_me_tuple_with_array(&(42, vec![(42, true); 42]));
+
+    assert!(simple_fallible(0).is_ok());
+    assert!(simple_fallible(42).is_err());
 }

--- a/tools/generator/test/languages/tester.cc
+++ b/tools/generator/test/languages/tester.cc
@@ -37,6 +37,7 @@ struct {
     int returns_inverse; // Test arrays of double
     int returns_reversed_enums; // Test arrays of enums
     int returns_upper; // Test arrays of strings
+    int simple_fallible;
 } func_called;
 
 extern "C"
@@ -256,6 +257,15 @@ extern "C"
         func_called.send_me_tuple_with_array += 1;
     }
 
+    test_error api_simple_fallible(int i) {
+        func_called.simple_fallible += 1;
+        if (i == 0) {
+            return test_error::OK;
+        } else {
+            return test_error::NON_ZERO;
+        }
+    }
+
     void api_afficher_test_enum(test_enum v)
     {
         assert(v == VAL2);
@@ -269,6 +279,7 @@ extern "C"
     void api_afficher_struct_with_only_double(struct_with_only_double) {}
     void api_afficher_simple_tuple(simple_tuple) {}
     void api_afficher_tuple_with_struct(tuple_with_struct) {}
+    void api_afficher_test_error(test_error) {}
 }
 
 
@@ -314,4 +325,5 @@ int main(int argc, char* argv[])
     assert(func_called.returns_inverse);
     assert(func_called.returns_reversed_enums);
     assert(func_called.returns_upper);
+    assert(func_called.simple_fallible);
 }


### PR DESCRIPTION
This PR implements support for idiomatic errors as discussed as part of #159.

### Design

Enumerations can be marked as `enum_error: yes` in configuration files. This tells `stechec` to treat the first variant of the enum as success ("OK") and all other variants as errors.

Marking an enum as an error changes its representation depending on the language:
- in Rust: `Result<(), Error>`
- in Haskell: `Either () Error`
- in OCaml: `(unit, error) result`
- in all other languages, the representation is unchanged compared to a regular enum